### PR TITLE
Add Rank Math SEO support (get/update SEO meta)

### DIFF
--- a/wsp-mcp-ai-agents-connector/includes/abilities/rankmath.php
+++ b/wsp-mcp-ai-agents-connector/includes/abilities/rankmath.php
@@ -1,0 +1,128 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+function wsp_rankmath_is_active() {
+    return class_exists( 'RankMath' ) || defined( 'RANK_MATH_VERSION' );
+}
+
+function wsp_rankmath_meta_key( $key ) {
+    $map = array(
+        'title'         => 'rank_math_title',
+        'description'   => 'rank_math_description',
+        'focus_keyword' => 'rank_math_focus_keyword',
+    );
+
+    return isset( $map[ $key ] ) ? $map[ $key ] : '';
+}
+
+function wsp_rankmath_get_meta( $post_id, $key ) {
+    $meta_key = wsp_rankmath_meta_key( $key );
+    if ( '' === $meta_key ) {
+        return '';
+    }
+
+    $value = get_post_meta( $post_id, $meta_key, true );
+    return is_string( $value ) ? $value : '';
+}
+
+function wsp_rankmath_set_meta( $post_id, $key, $value ) {
+    $meta_key = wsp_rankmath_meta_key( $key );
+    if ( '' === $meta_key ) {
+        return;
+    }
+
+    // Rank Math treats missing meta as "use the global template",
+    // so clearing a field should remove the row rather than store ''.
+    if ( '' === $value ) {
+        delete_post_meta( $post_id, $meta_key );
+        return;
+    }
+
+    update_post_meta( $post_id, $meta_key, $value );
+}
+
+function wsp_rankmath_validate_post( $post_id ) {
+    $post = get_post( $post_id );
+    if ( ! $post ) {
+        return new WP_Error( 'post_not_found', 'Post not found.' );
+    }
+
+    if ( ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
+        return new WP_Error( 'invalid_post_type', 'Rank Math SEO meta is only supported for posts and pages.' );
+    }
+
+    if ( ! current_user_can( 'edit_post', $post_id ) ) {
+        return new WP_Error( 'forbidden', 'You do not have permission to edit this post.' );
+    }
+
+    return $post;
+}
+
+function wsp_rankmath_format_seo_data( $post ) {
+    $post_id = $post->ID;
+    $score   = get_post_meta( $post_id, 'rank_math_seo_score', true );
+
+    return array(
+        'post_id'          => $post_id,
+        'post_type'        => $post->post_type,
+        'title'            => get_the_title( $post_id ),
+        'seo_title'        => wsp_rankmath_get_meta( $post_id, 'title' ),
+        'meta_description' => wsp_rankmath_get_meta( $post_id, 'description' ),
+        'focus_keyword'    => wsp_rankmath_get_meta( $post_id, 'focus_keyword' ),
+        'seo_score'        => '' === $score ? null : intval( $score ),
+        'url'              => get_permalink( $post_id ),
+    );
+}
+
+// ─────────────────────────────────────────────
+// EXECUTE
+// ─────────────────────────────────────────────
+
+function wsp_execute_rankmath_get_seo( $input ) {
+    $post_id = intval( $input['id'] );
+    $post    = wsp_rankmath_validate_post( $post_id );
+    if ( is_wp_error( $post ) ) {
+        return $post;
+    }
+
+    return wsp_rankmath_format_seo_data( $post );
+}
+
+function wsp_execute_rankmath_update_seo( $input ) {
+    $post_id = intval( $input['id'] );
+    $post    = wsp_rankmath_validate_post( $post_id );
+    if ( is_wp_error( $post ) ) {
+        return $post;
+    }
+
+    $updated = array();
+
+    if ( isset( $input['seo_title'] ) ) {
+        $value = sanitize_text_field( wp_unslash( $input['seo_title'] ) );
+        wsp_rankmath_set_meta( $post_id, 'title', $value );
+        $updated['seo_title'] = $value;
+    }
+
+    if ( isset( $input['meta_description'] ) ) {
+        $value = sanitize_textarea_field( wp_unslash( $input['meta_description'] ) );
+        wsp_rankmath_set_meta( $post_id, 'description', $value );
+        $updated['meta_description'] = $value;
+    }
+
+    if ( isset( $input['focus_keyword'] ) ) {
+        $value = sanitize_text_field( wp_unslash( $input['focus_keyword'] ) );
+        wsp_rankmath_set_meta( $post_id, 'focus_keyword', $value );
+        $updated['focus_keyword'] = $value;
+    }
+
+    if ( empty( $updated ) ) {
+        return new WP_Error( 'no_fields', 'Provide at least one of: seo_title, meta_description, focus_keyword.' );
+    }
+
+    return array(
+        'success' => true,
+        'id'      => $post_id,
+        'updated' => $updated,
+        'seo'     => wsp_rankmath_format_seo_data( get_post( $post_id ) ),
+    );
+}

--- a/wsp-mcp-ai-agents-connector/includes/admin/settings-page.php
+++ b/wsp-mcp-ai-agents-connector/includes/admin/settings-page.php
@@ -183,6 +183,7 @@ function wsp_mcp_settings_page() {
         'Site'                   => '🌐',
         'Elementor'              => '⚡',
         'Yoast SEO'              => '🔎',
+        'Rank Math SEO'          => '🎯',
         'WooCommerce'            => '🛍️',
         'Advanced Custom Fields' => '🧩',
     );

--- a/wsp-mcp-ai-agents-connector/includes/registry.php
+++ b/wsp-mcp-ai-agents-connector/includes/registry.php
@@ -57,6 +57,14 @@ function wsp_mcp_ability_registry() {
         );
     }
 
+    if ( wsp_rankmath_is_active() ) {
+        $abilities += array(
+            // RANK MATH SEO
+            'wsp/rankmath-get-seo'    => array( 'label' => 'Get Rank Math SEO Meta',    'description' => 'Get Rank Math SEO title, meta description, focus keyword, and SEO score for a post or page.', 'group' => 'Rank Math SEO', 'access' => 'read',  'default' => false ),
+            'wsp/rankmath-update-seo' => array( 'label' => 'Update Rank Math SEO Meta', 'description' => 'Update Rank Math SEO title, meta description, and/or focus keyword for a post or page.', 'group' => 'Rank Math SEO', 'access' => 'write', 'default' => false ),
+        );
+    }
+
     if ( class_exists( 'WooCommerce' ) ) {
         $abilities += array(
             // WOOCOMMERCE

--- a/wsp-mcp-ai-agents-connector/includes/tools/native-tools.php
+++ b/wsp-mcp-ai-agents-connector/includes/tools/native-tools.php
@@ -319,6 +319,31 @@ function wsp_mcp_register_native_tools() {
 		) );
 	}
 
+	// ---- Rank Math SEO (only when Rank Math is active) ----
+	if ( function_exists( 'wsp_rankmath_is_active' ) && wsp_rankmath_is_active() ) {
+		WSP_MCP_Server::register_tool( 'wsp_rankmath_get_seo', array(
+			'description' => 'Get Rank Math SEO title, meta description, focus keyword, and SEO score for a post or page.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id' => array( 'type' => 'integer' ),
+			) ),
+			'callback'    => 'wsp_execute_rankmath_get_seo',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/rankmath-get-seo',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_rankmath_update_seo', array(
+			'description' => 'Update Rank Math SEO title, meta description, and/or focus keyword for a post or page. Focus keyword accepts multiple comma-separated keywords (first one is the primary). Pass an empty string to clear a field back to the global template.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id'               => array( 'type' => 'integer' ),
+				'seo_title'        => array( 'type' => 'string' ),
+				'meta_description' => array( 'type' => 'string' ),
+				'focus_keyword'    => array( 'type' => 'string' ),
+			) ),
+			'callback'    => 'wsp_execute_rankmath_update_seo',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/rankmath-update-seo',
+		) );
+	}
+
 	// ---- WooCommerce (only when WooCommerce is active) ----
 	if ( class_exists( 'WooCommerce' ) ) {
 		WSP_MCP_Server::register_tool( 'wsp_woo_get_products', array(

--- a/wsp-mcp-ai-agents-connector/wsp-mcp-ai-agents-connector.php
+++ b/wsp-mcp-ai-agents-connector/wsp-mcp-ai-agents-connector.php
@@ -36,6 +36,7 @@ require_once WSP_MCP_DIR . 'includes/abilities/users.php';
 require_once WSP_MCP_DIR . 'includes/abilities/search.php';
 require_once WSP_MCP_DIR . 'includes/abilities/site.php';
 require_once WSP_MCP_DIR . 'includes/abilities/yoast.php';
+require_once WSP_MCP_DIR . 'includes/abilities/rankmath.php';
 require_once WSP_MCP_DIR . 'includes/abilities/elementor.php';
 require_once WSP_MCP_DIR . 'includes/abilities/woocommerce.php';
 require_once WSP_MCP_DIR . 'includes/abilities/acf.php'; // Included ACF Pro Abilities


### PR DESCRIPTION
This PR adds Rank Math SEO support, mirroring the existing Yoast module's structure.

## What's added

- New `includes/abilities/rankmath.php` with two abilities:
  - `wsp_rankmath_get_seo` — returns SEO title, meta description, focus keyword, read-only SEO score, and permalink for a post or page
  - `wsp_rankmath_update_seo` — updates SEO title, meta description, and/or focus keyword
- Registry entries (`wsp/rankmath-get-seo`, `wsp/rankmath-update-seo`) under a new "Rank Math SEO" group, registered only when Rank Math is active (`class_exists('RankMath')` or `RANK_MATH_VERSION`), both **default off** — matching the Yoast entries
- Native tool registration in `native-tools.php` behind the same `function_exists` guard used for Yoast
- Settings page group icon (🎯)

## Behavior notes

- Meta keys verified against the official Rank Math repo: `rank_math_title`, `rank_math_description`, `rank_math_focus_keyword`
- Passing an empty string **deletes** the meta row so the field falls back to the global template — this matches how Rank Math treats missing meta
- Focus keyword accepts multiple comma-separated keywords (first one is primary), as Rank Math stores them
- No indexable rebuild needed — unlike Yoast, Rank Math reads post meta directly at render time
- `seo_score` is returned read-only; it's computed client-side in the editor, so it refreshes the next time the post is opened in wp-admin

## Testing

- `php -l` clean on all changed files (PHP 8.5)
- 23 unit checks against a WP-stub harness: get / partial update / clear-to-template / `no_fields` / `post_not_found` / `invalid_post_type` / `forbidden` / activation detection — all passing
- Registry integration check: abilities appear only when Rank Math is active, defaults are off, settings merge is upgrade-safe
- Deployed and verified on a production WordPress 6.9 site with Rank Math installed — both tools work end-to-end over the native MCP endpoint

The bundled `wsp-mcp-ai-agents-connector.zip` was intentionally not rebuilt — I assume you regenerate it on release. Scope is post/page only (same as the Yoast module); happy to extend to products or other post types if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
