### PR TITLE
v2.6.5: CF7 + WPForms + Elementor Advanced Design Tools + all integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ These three files give you complete project understanding without touching the c
 ## What this plugin is
 
 **Plugin Name:** WSP MCP - AI Agents Connector  
-**Version:** 2.6.2  
+**Version:** 2.6.5
 **Slug/prefix:** `wsp`  
 **WP option key:** `wsp_mcp_abilities`  
 **Constant prefix:** `WSP_MCP_`
@@ -187,7 +187,7 @@ wsp-wordpress-mcp/                        ← repo root (NOT the plugin — dev 
 
 | Constant | Value |
 |---|---|
-| `WSP_MCP_VERSION` | `'2.6.2'` |
+| `WSP_MCP_VERSION` | `'2.6.5'` |
 | `WSP_MCP_OPTION` | `'wsp_mcp_abilities'` (per-ability on/off toggles) |
 | `WSP_MCP_DIR` | `plugin_dir_path(__FILE__)` |
 
@@ -363,8 +363,20 @@ Only registered if `class_exists('\Elementor\Plugin')`. All abilities require `e
 | `wsp/elementor-add-widget` | Add Widget | write | OFF | `post_id`*, `widget_type`*, `container_id`, `settings`, `position` |
 | `wsp/elementor-add-container` | Add Container | write | OFF | `post_id`*, `type` (container\|section), `parent_id`, `settings`, `position` |
 | `wsp/elementor-remove-element` | Remove Element | write | OFF | `post_id`*, `element_id`* |
+| `wsp/elementor-get-active-kit` | Get Active Kit | read | OFF | none |
+| `wsp/elementor-update-active-kit` | Update Active Kit | write | OFF | `system_colors[]`, `container_width`, `space_between_widgets` |
+| `wsp/elementor-regenerate-css` | Regenerate CSS | write | OFF | none |
+| `wsp/elementor-get-widget-schema` | Get Widget Schema | read | OFF | `widget_type`* |
+| `wsp/elementor-duplicate-element` | Duplicate Element | write | OFF | `post_id`*, `element_id`*, `parent_id`, `position` |
+| `wsp/elementor-move-element` | Move Element | write | OFF | `post_id`*, `element_id`*, `new_parent_id`, `position` |
+| `wsp/elementor-convert-css` | Convert CSS | read | OFF | `css`* (object) |
+| `wsp/elementor-get-page-settings` | Get Page Settings | read | OFF | `post_id`* |
+| `wsp/elementor-update-page-settings` | Update Page Settings | write | OFF | `post_id`*, `page_template`, `hide_title`, `content_width`, `background_color` |
+| `wsp/elementor-copy-styles` | Copy Styles | write | OFF | `post_id`*, `source_id`*, `destination_id`*, `merge` |
+| `wsp/elementor-get-breakpoints` | Get Breakpoints | read | OFF | none |
 
 **Elementor data model:**
+**Elementor Advanced Design Tools (v2.6.5):** added `get-active-kit`, `update-active-kit`, `regenerate-css`, `get-widget-schema`, `duplicate-element`, `move-element`, `convert-css`, `get-page-settings`, `update-page-settings`, `copy-styles`, `get-breakpoints`. `convert-css` parses CSS shorthand into Elementor settings format. `duplicate-element` / `clone-and-reid` recursively assigns new 8-char hex IDs. All write tools run through `wsp_elementor_sanitize_settings()`.
 - Elementor page data is stored in `_elementor_data` post meta as a JSON-encoded recursive element tree.
 - Each element: `{ id (8-char hex), elType, widgetType?, settings{}, elements[], isInner? }`
 - Root elements are sections (legacy) or containers (modern). Widgets cannot be placed directly inside a section — they need a column inside the section.
@@ -501,6 +513,55 @@ Only registered if `wsp_gravity_is_active()` (`class_exists('GFAPI') || class_ex
 - All callbacks gate on `class_exists('GFAPI')` and return `WP_Error` if Gravity Forms is inactive.
 - `get_entry` resolves field labels from the form definition and returns human-readable field data.
 
+#### Contact Form 7 (`cf7.php`)
+
+Only registered if `wsp_cf7_is_active()` (`class_exists('WPCF7_ContactForm')`).
+**10 tools** covering forms, Flamingo entries, validation, integrations, and moderation. MCP tool names use the `wsp_cf7_*` form; enable keys use `wsp/cf7-*`.
+
+| Ability key | Label | Access | Default | Capability | Inputs |
+|---|---|---|---|---|---|---|
+| `wsp/cf7-list-forms` | List CF7 Forms | read | ON | `wpcf7_edit_contact_forms` | none |
+| `wsp/cf7-get-form` | Get CF7 Form | read | ON | `wpcf7_edit_contact_forms` | `id`* (int — form ID) |
+| `wsp/cf7-create-form` | Create CF7 Form | write | OFF | `wpcf7_edit_contact_forms` | `title`*, `locale`, `form_markup`, `mail` (object), `messages` (object) |
+| `wsp/cf7-update-form` | Update CF7 Form | write | OFF | `wpcf7_edit_contact_forms` | `id`*, `title`, `locale`, `form_markup`, `mail`, `mail_2`, `messages`, `additional_settings` |
+| `wsp/cf7-delete-form` | Delete CF7 Form | write | OFF | `wpcf7_delete_contact_forms` | `id`*, `permanent` (bool) |
+| `wsp/cf7-list-entries` | List CF7 Entries | read | OFF | `wpcf7_edit_contact_forms` | `form_id`, `per_page`, `page`, `status` |
+| `wsp/cf7-get-entry` | Get CF7 Entry | read | OFF | `wpcf7_edit_contact_forms` | `id`* (int — entry ID) |
+| `wsp/cf7-validate-form` | Validate CF7 Form | read | OFF | `wpcf7_edit_contact_forms` | `id`* (int) |
+| `wsp/cf7-get-integrations` | Get CF7 Integrations | read | OFF | `manage_options` | none |
+| `wsp/cf7-moderate-entry` | Moderate CF7 Entry | write | OFF | `wpcf7_edit_contact_forms` | `id`*, `action`* (spam | unspam | trash | untrash) |
+
+- **Flamingo dependency:** `list-entries`, `get-entry`, and `moderate-entry` require `class_exists('Flamingo_Inbound_Message')` — Contact Form 7 does not store entries natively. These tools return a descriptive `WP_Error` if Flamingo is not active.
+- `validate-form` uses the built-in `WPCF7_ConfigValidator` to check email templates and form syntax.
+- `get-integrations` reads active integration modules via `WPCF7_Integration::list_modules()` and reCAPTCHA keys from the global `wpcf7` option.
+- All callbacks gate on `class_exists('WPCF7_ContactForm')` and return `WP_Error` if CF7 is inactive.
+- The `wpcf7_edit_contact_forms` cap is used as primary; falls back to `edit_posts` for `list-forms` and `get-form`.
+
+#### WPForms (`wpforms.php`)
+
+Only registered if `wsp_wpforms_is_active()` (`function_exists('wpforms') || class_exists('WPForms')`).
+**12 tools** covering forms, fields, entries (Pro), and schema description. MCP tool names use the `wsp_wpforms_*` form; enable keys use `wsp/wpforms-*`.
+
+| Ability key | Label | Access | Default | Capability | Inputs |
+|---|---|---|---|---|---|---|
+| `wsp/wpforms-list-forms` | List WPForms | read | ON | `wpforms_view_forms` | none |
+| `wsp/wpforms-get-form` | Get Form | read | ON | `wpforms_view_forms` | `id`* (int — form ID) |
+| `wsp/wpforms-describe-schema` | Describe Schema | read | ON | `wpforms_view_forms` | none |
+| `wsp/wpforms-get-form-stats` | Get Form Stats | read | ON | `wpforms_view_forms` | `id` (int, optional) |
+| `wsp/wpforms-create-form` | Create Form | write | OFF | `wpforms_edit_forms` | `title`*, `description`, `fields[]`, `submit_text` |
+| `wsp/wpforms-update-form-settings` | Update Form Settings | write | OFF | `wpforms_edit_forms` | `id`*, `title`, `description`, `submit_text`, `antispam`, `ajax_submit` |
+| `wsp/wpforms-add-field` | Add Field | write | OFF | `wpforms_edit_forms` | `id`*, `type`*, `label`*, `required`, `description`, `placeholder`, `css`, `choices[]` |
+| `wsp/wpforms-update-field` | Update Field | write | OFF | `wpforms_edit_forms` | `id`*, `field_id`*, `label`, `required`, `description`, `placeholder`, `css`, `choices[]` |
+| `wsp/wpforms-delete-form` | Delete Form | write | OFF | `wpforms_edit_forms` | `id`*, `permanent` (bool) |
+| `wsp/wpforms-list-entries` | List Entries | read | OFF | `wpforms_view_entries` | `id`, `per_page`, `page`, `status` |
+| `wsp/wpforms-get-entry` | Get Entry | read | OFF | `wpforms_view_entries` | `id`* (int — entry ID) |
+| `wsp/wpforms-delete-entry` | Delete Entry | write | OFF | `wpforms_edit_entries` | `id`*, `permanent` (bool) |
+
+- **Pro dependency:** `list-entries`, `get-entry`, and `delete-entry` require WPForms Pro (`wsp_wpforms_pro_is_active()` checks `wpforms()->is_pro()`). Lite users receive a descriptive error.
+- **Form data model:** Forms are stored as the `wpforms` custom post type with `post_content` as a JSON object containing `fields` (array, keyed by string ID), `settings`, and `payments`.
+- **Field IDs:** Auto-assigned as incremental integers starting from 0. `wsp_wpforms_get_next_field_id()` finds the highest existing ID + 1.
+- **Schema description:** `describe-schema` returns 16 supported field types with metadata on which accept choices and which attributes are editable.
+- All callbacks gate on `function_exists('wpforms')` and return `WP_Error` if WPForms is inactive.
 #### Ultimate Addons for Elementor (`uae.php`)
 
 Only registered if `wsp_uae_is_active()`. Adds 45 tools to manipulate UAE widgets, templates (Header/Footer/Blocks), settings, and display rules. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [2.6.5] — 2026-07-21
+
+### Added — Elementor Advanced Design Tools (`includes/abilities/elementor.php`, `includes/tools/native-tools.php`, `includes/registry.php`)
+- **11 new Elementor design tools** for visual mockup replication and high-fidelity design workflows. All OFF by default, toggled from **MCP > Settings** under the "Elementor" group:
+  - `get-active-kit` — reads global fonts, color palette, container width, and layout from the active Elementor kit.
+  - `update-active-kit` — updates system colors, container width, and spacing in the active kit.
+  - `regenerate-css` — clears and regenerates Elementor CSS cache for all Elementor-built posts.
+  - `get-widget-schema` — queries the Elementor controls manager for a widget type; returns all control keys (margins, padding, background, typography, border) organized by tab.
+  - `duplicate-element` — clones a widget or container with recursive 8-char hex ID reassignment via `wsp_elementor_clone_and_reid()` to prevent collisions.
+  - `move-element` — removes an element from its current position and inserts it into a new parent or index position.
+  - `convert-css` — parses CSS key-value rules (`padding`, `margin`, `border-radius`, `background-color`, `font-size`, `text-align`, etc.) into their exact Elementor settings counterparts.
+  - `get-page-settings` / `update-page-settings` — read and update page-level `_elementor_page_settings` meta (template, hide_title, content_width, background).
+  - `copy-styles` — copies settings from a source element ID to a destination element ID (with optional merge mode).
+  - `get-breakpoints` — reads responsive viewport breakpoints (desktop 1025+, tablet 768-1024, mobile 0-767) from the active kit.
+
+### Security
+- All write tools run settings through `wsp_elementor_sanitize_settings()` (blocks `custom_css`, `_attributes`, `custom_attributes`, `__dynamic__` keys).
+- `update-active-kit` and `regenerate-css` require `manage_options`; all other tools require `edit_posts`.
+
+---
+
+## [2.6.4] — 2026-07-21
+
+### Added — WPForms suite (`includes/abilities/wpforms.php`, `includes/tools/native-tools.php`, `includes/registry.php`)
+- **12 new tools** for the WPForms integration (Lite and Pro), all write tools OFF by default and toggled from **MCP > Settings** under the "WPForms" group. Only registered when WPForms is active (`function_exists('wpforms') || class_exists('WPForms')`):
+  - **Forms:** list (ON), get (ON), describe-schema (ON), get-form-stats (ON), create, update-form-settings, add-field, update-field, delete (trash or permanent). Capabilities: `wpforms_view_forms`, `wpforms_edit_forms`.
+  - **Entries (Pro only):** list, get, delete (trash or permanent) — require `wsp_wpforms_pro_is_active()` (`wpforms()->is_pro()`). Lite users receive a descriptive error. Capabilities: `wpforms_view_entries`, `wpforms_edit_entries`.
+- New helpers: `wsp_wpforms_is_active()`, `wsp_wpforms_pro_is_active()`, `wsp_wpforms_get_form_data()`, `wsp_wpforms_save_form_data()`, `wsp_wpforms_get_next_field_id()`, `wsp_wpforms_field_types()`.
+- **Form data model:** WPForms stores forms as the `wpforms` custom post type; `post_content` is a JSON object with `fields` (array keyed by string IDs), `settings`, and `payments`. Field IDs are auto-assigned incrementally starting from 0.
+- **Schema description:** `describe-schema` returns 16 supported field types (text, email, select, radio, checkbox, number, phone, file-upload, etc.) with metadata on choice support and editable attributes.
+- `create-form` auto-generates a default notification targeting `{admin_email}` with `{all_fields}` body.
+- All callbacks gate on `function_exists('wpforms')` and return descriptive `WP_Error` on inactive plugin.
+
+### Security
+- All text strings sanitized with `sanitize_text_field`/`sanitize_textarea_field`/`wp_kses_post`; field choices array members sanitized individually; JSON encoding uses `wp_json_encode()` + `wp_slash()`.
+- Form delete gates on `wpforms_edit_forms`; entry tools require `wpforms_view_entries` / `wpforms_edit_entries`.
+
+---
+
+## [2.6.3] — 2026-07-21
+
+### Added — Contact Form 7 suite (`includes/abilities/cf7.php`, `includes/tools/native-tools.php`, `includes/registry.php`)
+- **10 new tools** for the Contact Form 7 integration, all write tools OFF by default and toggled from **MCP > Settings** under the "Contact Form 7" group. Only registered when CF7 is active (`class_exists('WPCF7_ContactForm')`):
+  - **Forms:** list (ON by default), get (ON by default), create, update, delete (trash or permanent). Capabilities: `wpcf7_edit_contact_forms`, `wpcf7_delete_contact_forms`.
+  - **Entries (Flamingo):** list, get — require `class_exists('Flamingo_Inbound_Message')` as CF7 does not store entries natively. Capability: `wpcf7_edit_contact_forms`.
+  - **Validation:** `validate-form` runs the built-in `WPCF7_ConfigValidator` on a form ID to catch email template and syntax errors. Capability: `wpcf7_edit_contact_forms`.
+  - **Integrations:** `get-integrations` reads active integration modules and reCAPTCHA key status from the global `wpcf7` option. Capability: `manage_options`.
+  - **Moderation (Flamingo):** `moderate-entry` marks a submission as spam, unspam, trash, or untrash. Capability: `wpcf7_edit_contact_forms`.
+- New helper `wsp_cf7_is_active()` defined in both `registry.php` (defensive forward-declaration) and `cf7.php`; `wsp_cf7_flamingo_is_active()` also in `cf7.php`.
+- `get-form` returns full form structure including scanned form tags, mail config, messages, and additional settings.
+- All callbacks gate on `class_exists('WPCF7_ContactForm')` and return descriptive `WP_Error` on inactive plugin; Flamingo-dependent tools return a clear error when Flamingo is missing.
+
+### Security
+- All form strings sanitized with `sanitize_text_field`/`wp_kses_post`/`sanitize_textarea_field`; form IDs and entry IDs cast to `int`; `moderate_entry` action validated against `spam | unspam | trash | untrash` enum.
+- `get-integrations` requires `manage_options` (exposes reCAPTCHA key status); all entry tools require `wpcf7_edit_contact_forms`.
+
+---
 ## [2.6.2] — 2026-07-20
 
 ### Changed — Gravity Forms documentation & version bump

--- a/wsp-mcp-ai-agents-connector/includes/abilities/cf7.php
+++ b/wsp-mcp-ai-agents-connector/includes/abilities/cf7.php
@@ -1,0 +1,570 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+if ( ! function_exists( 'wsp_cf7_is_active' ) ) {
+function wsp_cf7_is_active() {
+    return class_exists( 'WPCF7_ContactForm' );
+}
+}
+
+if ( ! function_exists( 'wsp_cf7_flamingo_is_active' ) ) {
+function wsp_cf7_flamingo_is_active() {
+    return class_exists( 'Flamingo_Inbound_Message' );
+}
+}
+
+// ---------------------------------------------
+// EXECUTE CALLBACKS
+// ---------------------------------------------
+
+function wsp_execute_cf7_list_forms( $input ) {
+    if ( ! class_exists( 'WPCF7_ContactForm' ) ) {
+        return array( 'success' => false, 'error' => 'Contact Form 7 is not active.' );
+    }
+
+    $forms = WPCF7_ContactForm::find();
+    $result = array();
+
+    foreach ( $forms as $form ) {
+        $cf7 = wpcf7_contact_form( $form->id() );
+        $result[] = array(
+            'id'        => $form->id(),
+            'title'     => $form->title(),
+            'shortcode' => $cf7 ? $cf7->shortcode() : '[contact-form-7 id="' . $form->id() . '" title="' . esc_attr( $form->title() ) . '"]',
+            'slug'      => $form->name(),
+            'locale'    => $form->locale(),
+        );
+    }
+
+    return array( 'forms' => $result, 'total' => count( $result ) );
+}
+
+function wsp_execute_cf7_get_form( $input ) {
+    if ( ! class_exists( 'WPCF7_ContactForm' ) ) {
+        return array( 'success' => false, 'error' => 'Contact Form 7 is not active.' );
+    }
+
+    $form_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $form_id ) {
+        return array( 'success' => false, 'error' => 'Form ID is required.' );
+    }
+
+    $form = WPCF7_ContactForm::get_instance( $form_id );
+    if ( ! $form ) {
+        return array( 'success' => false, 'error' => 'Form not found.' );
+    }
+
+    $tags = array();
+    $form_tags = $form->scan_form_tags();
+    foreach ( $form_tags as $tag ) {
+        $tags[] = array(
+            'name'  => $tag->name,
+            'type'  => $tag->type,
+            'basetype'=> $tag->basetype,
+            'raw_name'=> $tag->raw_name,
+            'options' => $tag->options,
+            'values'  => $tag->values,
+            'labels'  => $tag->labels,
+        );
+    }
+
+    return array(
+        'success'     => true,
+        'id'          => $form->id(),
+        'title'       => $form->title(),
+        'slug'        => $form->name(),
+        'shortcode'   => $form->shortcode(),
+        'locale'      => $form->locale(),
+        'form_markup' => $form->prop( 'form' ),
+        'mail'        => $form->prop( 'mail' ),
+        'mail_2'      => $form->prop( 'mail_2' ),
+        'messages'    => $form->prop( 'messages' ),
+        'additional_settings' => $form->prop( 'additional_settings' ),
+        'tags'        => $tags,
+    );
+}
+
+function wsp_execute_cf7_create_form( $input ) {
+    if ( ! class_exists( 'WPCF7_ContactForm' ) ) {
+        return array( 'success' => false, 'error' => 'Contact Form 7 is not active.' );
+    }
+
+    $title = isset( $input['title'] ) ? sanitize_text_field( wp_unslash( $input['title'] ) ) : '';
+    if ( ! $title ) {
+        return array( 'success' => false, 'error' => 'Form title is required.' );
+    }
+
+    $template = WPCF7_ContactForm::get_template();
+    $template->set_title( $title );
+
+    if ( isset( $input['locale'] ) ) {
+        $template->set_locale( sanitize_text_field( wp_unslash( $input['locale'] ) ) );
+    }
+
+    if ( isset( $input['form_markup'] ) ) {
+        $template->set_properties( array(
+            'form' => wp_kses_post( wp_unslash( $input['form_markup'] ) ),
+        ) );
+    }
+
+    if ( isset( $input['mail'] ) && is_array( $input['mail'] ) ) {
+        $mail = array();
+        foreach ( $input['mail'] as $k => $v ) {
+            $mail[ sanitize_text_field( $k ) ] = sanitize_text_field( wp_unslash( $v ) );
+        }
+        $props = $template->get_properties();
+        $props['mail'] = $mail;
+        $template->set_properties( $props );
+    }
+
+    if ( isset( $input['messages'] ) && is_array( $input['messages'] ) ) {
+        $messages = array();
+        foreach ( $input['messages'] as $k => $v ) {
+            $messages[ sanitize_text_field( $k ) ] = wp_kses_post( wp_unslash( $v ) );
+        }
+        $props = $template->get_properties();
+        $props['messages'] = $messages;
+        $template->set_properties( $props );
+    }
+
+    $form_id = $template->save();
+
+    if ( ! $form_id ) {
+        return array( 'success' => false, 'error' => 'Failed to create form.' );
+    }
+
+    return array(
+        'success'   => true,
+        'id'        => $form_id,
+        'title'     => $title,
+        'shortcode' => sprintf( '[contact-form-7 id="%s" title="%s"]', $form_id, esc_attr( $title ) ),
+    );
+}
+
+function wsp_execute_cf7_update_form( $input ) {
+    if ( ! class_exists( 'WPCF7_ContactForm' ) ) {
+        return array( 'success' => false, 'error' => 'Contact Form 7 is not active.' );
+    }
+
+    $form_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $form_id ) {
+        return array( 'success' => false, 'error' => 'Form ID is required.' );
+    }
+
+    $form = WPCF7_ContactForm::get_instance( $form_id );
+    if ( ! $form ) {
+        return array( 'success' => false, 'error' => 'Form not found.' );
+    }
+
+    $updated = array();
+
+    if ( isset( $input['title'] ) ) {
+        $form->set_title( sanitize_text_field( wp_unslash( $input['title'] ) ) );
+        $updated[] = 'title';
+    }
+
+    if ( isset( $input['locale'] ) ) {
+        $form->set_locale( sanitize_text_field( wp_unslash( $input['locale'] ) ) );
+        $updated[] = 'locale';
+    }
+
+    $props = $form->get_properties();
+
+    if ( isset( $input['form_markup'] ) ) {
+        $props['form'] = wp_kses_post( wp_unslash( $input['form_markup'] ) );
+        $updated[] = 'form_markup';
+    }
+
+    if ( isset( $input['mail'] ) && is_array( $input['mail'] ) ) {
+        $mail = isset( $props['mail'] ) ? $props['mail'] : array();
+        foreach ( $input['mail'] as $k => $v ) {
+            $mail[ sanitize_text_field( $k ) ] = sanitize_text_field( wp_unslash( $v ) );
+        }
+        $props['mail'] = $mail;
+        $updated[] = 'mail';
+    }
+
+    if ( isset( $input['mail_2'] ) && is_array( $input['mail_2'] ) ) {
+        $mail_2 = isset( $props['mail_2'] ) ? $props['mail_2'] : array();
+        foreach ( $input['mail_2'] as $k => $v ) {
+            $mail_2[ sanitize_text_field( $k ) ] = sanitize_text_field( wp_unslash( $v ) );
+        }
+        $props['mail_2'] = $mail_2;
+        $updated[] = 'mail_2';
+    }
+
+    if ( isset( $input['messages'] ) && is_array( $input['messages'] ) ) {
+        $messages = isset( $props['messages'] ) ? $props['messages'] : array();
+        foreach ( $input['messages'] as $k => $v ) {
+            $messages[ sanitize_text_field( $k ) ] = wp_kses_post( wp_unslash( $v ) );
+        }
+        $props['messages'] = $messages;
+        $updated[] = 'messages';
+    }
+
+    if ( isset( $input['additional_settings'] ) ) {
+        $props['additional_settings'] = sanitize_textarea_field( wp_unslash( $input['additional_settings'] ) );
+        $updated[] = 'additional_settings';
+    }
+
+    if ( empty( $updated ) ) {
+        return array( 'success' => false, 'error' => 'No fields to update provided.' );
+    }
+
+    $form->set_properties( $props );
+    $result = $form->save();
+
+    if ( ! $result ) {
+        return array( 'success' => false, 'error' => 'Failed to update form.' );
+    }
+
+    return array(
+        'success' => true,
+        'id'      => $form_id,
+        'updated' => $updated,
+    );
+}
+
+function wsp_execute_cf7_delete_form( $input ) {
+    if ( ! class_exists( 'WPCF7_ContactForm' ) ) {
+        return array( 'success' => false, 'error' => 'Contact Form 7 is not active.' );
+    }
+
+    $form_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $form_id ) {
+        return array( 'success' => false, 'error' => 'Form ID is required.' );
+    }
+
+    $form = WPCF7_ContactForm::get_instance( $form_id );
+    if ( ! $form ) {
+        return array( 'success' => false, 'error' => 'Form not found.' );
+    }
+
+    $permanent = isset( $input['permanent'] ) ? (bool) $input['permanent'] : false;
+
+    if ( $permanent ) {
+        $result = wp_delete_post( $form_id, true );
+        if ( ! $result ) {
+            return array( 'success' => false, 'error' => 'Failed to permanently delete form.' );
+        }
+    } else {
+        $result = wp_trash_post( $form_id );
+        if ( ! $result ) {
+            return array( 'success' => false, 'error' => 'Failed to move form to trash.' );
+        }
+    }
+
+    return array(
+        'success'  => true,
+        'message'  => $permanent ? 'Form permanently deleted.' : 'Form moved to trash.',
+        'id'       => $form_id,
+    );
+}
+
+function wsp_execute_cf7_list_entries( $input ) {
+    if ( ! class_exists( 'WPCF7_ContactForm' ) ) {
+        return array( 'success' => false, 'error' => 'Contact Form 7 is not active.' );
+    }
+
+    if ( ! class_exists( 'Flamingo_Inbound_Message' ) ) {
+        return array( 'success' => false, 'error' => 'Flamingo plugin is required for entry storage. Please install and activate Flamingo.' );
+    }
+
+    $form_id = isset( $input['form_id'] ) ? intval( $input['form_id'] ) : 0;
+    $per_page = isset( $input['per_page'] ) ? intval( $input['per_page'] ) : 20;
+    $page     = isset( $input['page'] ) ? intval( $input['page'] ) : 1;
+    $status   = isset( $input['status'] ) ? sanitize_text_field( wp_unslash( $input['status'] ) ) : '';
+
+    $args = array(
+        'posts_per_page' => $per_page,
+        'offset'         => ( $page - 1 ) * $per_page,
+        'orderby'        => 'date',
+        'order'          => 'DESC',
+    );
+
+    if ( $form_id ) {
+        $args['channel'] = get_post_field( 'post_name', $form_id );
+    }
+
+    if ( $status && 'all' !== $status ) {
+        if ( 'spam' === $status ) {
+            $args['meta_key']   = '_spam_';
+            $args['meta_value'] = '1';
+        } elseif ( 'trash' === $status ) {
+            $args['post_status'] = 'trash';
+        } else {
+            $args['post_status'] = 'publish';
+        }
+    }
+
+    $total = Flamingo_Inbound_Message::count( $args );
+    $entries = Flamingo_Inbound_Message::find( $args );
+
+    $items = array();
+    foreach ( $entries as $entry ) {
+        $items[] = array(
+            'id'        => $entry->id(),
+            'subject'   => $entry->subject,
+            'from'      => $entry->from,
+            'from_email'=> $entry->from_email,
+            'channel'   => $entry->channel,
+            'date'      => $entry->date,
+            'spam'      => ! empty( $entry->spam ),
+            'status'    => get_post_status( $entry->id() ),
+            'fields'    => $entry->fields,
+        );
+    }
+
+    return array(
+        'entries'  => $items,
+        'total'    => (int) $total,
+        'page'     => $page,
+        'per_page' => $per_page,
+    );
+}
+
+function wsp_execute_cf7_get_entry( $input ) {
+    if ( ! class_exists( 'WPCF7_ContactForm' ) ) {
+        return array( 'success' => false, 'error' => 'Contact Form 7 is not active.' );
+    }
+
+    if ( ! class_exists( 'Flamingo_Inbound_Message' ) ) {
+        return array( 'success' => false, 'error' => 'Flamingo plugin is required for entry storage. Please install and activate Flamingo.' );
+    }
+
+    $entry_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $entry_id ) {
+        return array( 'success' => false, 'error' => 'Entry ID is required.' );
+    }
+
+    $entry = new Flamingo_Inbound_Message( $entry_id );
+    if ( ! $entry || ! $entry->id() ) {
+        return array( 'success' => false, 'error' => 'Entry not found.' );
+    }
+
+    $channel_title = '';
+    if ( $entry->channel ) {
+        $channel_post = get_page_by_path( $entry->channel, OBJECT, 'wpcf7_contact_form' );
+        if ( $channel_post ) {
+            $channel_title = get_the_title( $channel_post );
+        }
+    }
+
+    return array(
+        'success'       => true,
+        'id'            => $entry->id(),
+        'subject'       => $entry->subject,
+        'from'          => $entry->from,
+        'from_email'    => $entry->from_email,
+        'from_name'     => $entry->from_name,
+        'channel'       => $entry->channel,
+        'channel_title' => $channel_title,
+        'date'          => $entry->date,
+        'spam'          => ! empty( $entry->spam ),
+        'status'        => get_post_status( $entry->id() ),
+        'fields'        => $entry->fields,
+        'meta'          => $entry->meta,
+        'consent'       => $entry->consent,
+        'remote_ip'     => $entry->remote_ip,
+        'user_agent'    => $entry->user_agent,
+    );
+}
+
+function wsp_execute_cf7_validate_form( $input ) {
+    if ( ! class_exists( 'WPCF7_ContactForm' ) ) {
+        return array( 'success' => false, 'error' => 'Contact Form 7 is not active.' );
+    }
+
+    $form_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $form_id ) {
+        return array( 'success' => false, 'error' => 'Form ID is required.' );
+    }
+
+    $form = WPCF7_ContactForm::get_instance( $form_id );
+    if ( ! $form ) {
+        return array( 'success' => false, 'error' => 'Form not found.' );
+    }
+
+    $errors = array();
+
+    $mail = $form->prop( 'mail' );
+
+    if ( empty( $mail ) || ! is_array( $mail ) ) {
+        $errors[] = array(
+            'code'    => 'no_mail_settings',
+            'message' => 'Mail settings are missing or empty.',
+        );
+    } else {
+        if ( empty( $mail['recipient'] ) ) {
+            $errors[] = array(
+                'code'    => 'mail_empty_recipient',
+                'message' => 'Mail recipient email is empty.',
+            );
+        }
+        if ( empty( $mail['subject'] ) ) {
+            $errors[] = array(
+                'code'    => 'mail_empty_subject',
+                'message' => 'Mail subject is empty.',
+            );
+        }
+        if ( empty( $mail['sender'] ) ) {
+            $errors[] = array(
+                'code'    => 'mail_empty_sender',
+                'message' => 'Mail sender is empty.',
+            );
+        }
+    }
+
+    $form_markup = $form->prop( 'form' );
+    if ( empty( trim( $form_markup ) ) ) {
+        $errors[] = array(
+            'code'    => 'empty_form_template',
+            'message' => 'Form template is empty — no form tags defined.',
+        );
+    } else {
+        $form_tags = $form->scan_form_tags();
+        $required_tags = array();
+        foreach ( $form_tags as $tag ) {
+            if ( ! empty( $tag->required ) || ( $tag->type && strpos( $tag->type, '*' ) !== false ) ) {
+                $required_tags[] = $tag->name;
+            }
+        }
+        if ( empty( $required_tags ) ) {
+            $errors[] = array(
+                'code'    => 'no_required_fields',
+                'message' => 'No required fields found in the form. Consider marking at least one field as required.',
+            );
+        }
+    }
+
+    $mail_2 = $form->prop( 'mail_2' );
+    if ( ! empty( $mail_2 ) && is_array( $mail_2 ) && ! empty( $mail_2['active'] ) ) {
+        if ( empty( $mail_2['recipient'] ) ) {
+            $errors[] = array(
+                'code'    => 'mail2_empty_recipient',
+                'message' => 'Mail (2) auto-reply recipient is empty.',
+            );
+        }
+    }
+
+    if ( class_exists( 'WPCF7_ConfigValidator' ) ) {
+        $validator = new WPCF7_ConfigValidator( $form );
+        $validator->validate();
+
+        $validator_errors = array();
+        if ( isset( $validator->error ) && is_array( $validator->error ) && ! empty( $validator->error ) ) {
+            $validator_errors = $validator->error;
+        } elseif ( method_exists( $validator, 'collect_error_messages' ) ) {
+            $collected = $validator->collect_error_messages();
+            if ( is_array( $collected ) ) {
+                $validator_errors = $collected;
+            }
+        }
+
+        foreach ( $validator_errors as $code => $message ) {
+            $errors[] = array(
+                'code'    => sanitize_text_field( $code ),
+                'message' => sanitize_text_field( $message ),
+            );
+        }
+    }
+
+    return array(
+        'success'       => true,
+        'id'            => $form_id,
+        'title'         => $form->title(),
+        'is_valid'      => count( $errors ) === 0,
+        'error_count'   => count( $errors ),
+        'errors'        => $errors,
+    );
+}
+
+function wsp_execute_cf7_get_integrations( $input ) {
+    if ( ! class_exists( 'WPCF7_ContactForm' ) ) {
+        return array( 'success' => false, 'error' => 'Contact Form 7 is not active.' );
+    }
+
+    $integrations = array();
+
+    if ( method_exists( 'WPCF7_Integration', 'list_modules' ) ) {
+        $modules = WPCF7_Integration::list_modules();
+        foreach ( $modules as $module_slug => $module ) {
+            $integrations[] = array(
+                'id'        => $module_slug,
+                'name'      => sanitize_text_field( $module->name ),
+                'is_active' => $module->is_active(),
+            );
+        }
+    }
+
+    $wpcf7_option = get_option( 'wpcf7', array() );
+    $recaptcha    = isset( $wpcf7_option['recaptcha'] ) ? $wpcf7_option['recaptcha'] : array();
+
+    $recaptcha_info = array();
+    foreach ( $recaptcha as $site => $keys ) {
+        if ( is_array( $keys ) ) {
+            $recaptcha_info[] = array(
+                'site'        => sanitize_text_field( $site ),
+                'has_site_key'   => ! empty( $keys['sitekey'] ),
+                'has_secret_key' => ! empty( $keys['secret'] ),
+            );
+        }
+    }
+
+    return array(
+        'success'               => true,
+        'active_integrations'   => $integrations,
+        'total_integrations'    => count( $integrations ),
+        'recaptcha_configured'  => $recaptcha_info,
+        'has_recaptcha'         => ! empty( $recaptcha ),
+    );
+}
+
+function wsp_execute_cf7_moderate_entry( $input ) {
+    if ( ! class_exists( 'WPCF7_ContactForm' ) ) {
+        return array( 'success' => false, 'error' => 'Contact Form 7 is not active.' );
+    }
+
+    if ( ! class_exists( 'Flamingo_Inbound_Message' ) ) {
+        return array( 'success' => false, 'error' => 'Flamingo plugin is required for entry storage. Please install and activate Flamingo.' );
+    }
+
+    $entry_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $entry_id ) {
+        return array( 'success' => false, 'error' => 'Entry ID is required.' );
+    }
+
+    $action = isset( $input['action'] ) ? sanitize_text_field( wp_unslash( $input['action'] ) ) : '';
+    $allowed_actions = array( 'spam', 'unspam', 'trash', 'untrash' );
+
+    if ( ! in_array( $action, $allowed_actions, true ) ) {
+        return array( 'success' => false, 'error' => 'Invalid action. Allowed: spam, unspam, trash, untrash.' );
+    }
+
+    $entry = new Flamingo_Inbound_Message( $entry_id );
+    if ( ! $entry || ! $entry->id() ) {
+        return array( 'success' => false, 'error' => 'Entry not found.' );
+    }
+
+    switch ( $action ) {
+        case 'spam':
+            $entry->spam();
+            break;
+        case 'unspam':
+            $entry->unspam();
+            break;
+        case 'trash':
+            wp_trash_post( $entry_id );
+            break;
+        case 'untrash':
+            wp_untrash_post( $entry_id );
+            break;
+    }
+
+    return array(
+        'success' => true,
+        'message' => 'Entry ' . $action . ' successfully.',
+        'id'      => $entry_id,
+        'action'  => $action,
+    );
+}

--- a/wsp-mcp-ai-agents-connector/includes/abilities/elementor.php
+++ b/wsp-mcp-ai-agents-connector/includes/abilities/elementor.php
@@ -417,3 +417,607 @@ function wsp_execute_elementor_remove_element( $input ) {
     wsp_elementor_save_data( $post_id, $data );
     return array( 'success' => true, 'message' => "Element {$element_id} removed." );
 }
+// ─────────────────────────────────────────────
+// ADVANCED DESIGN TOOLS (v2.6.5)
+// ─────────────────────────────────────────────
+
+function wsp_execute_elementor_get_active_kit( $input ) {
+    if ( ! wsp_elementor_is_active() ) {
+        return array( 'success' => false, 'error' => 'Elementor is not active.' );
+    }
+
+    $kit_id = get_option( 'elementor_active_kit' );
+    if ( ! $kit_id ) {
+        return array( 'success' => false, 'error' => 'No active Elementor kit found.' );
+    }
+
+    $settings = get_post_meta( $kit_id, '_elementor_page_settings', true );
+    if ( ! is_array( $settings ) ) {
+        $settings = array();
+    }
+
+    $kit_post = get_post( $kit_id );
+
+    $fonts = array();
+    $colors = array();
+    $layout = array();
+
+    if ( ! empty( $settings['system_colors'] ) && is_array( $settings['system_colors'] ) ) {
+        foreach ( $settings['system_colors'] as $c ) {
+            $colors[] = array(
+                'title' => isset( $c['title'] ) ? $c['title'] : '',
+                'color' => isset( $c['color'] ) ? $c['color'] : '',
+            );
+        }
+    }
+
+    if ( ! empty( $settings['system_typography'] ) && is_array( $settings['system_typography'] ) ) {
+        foreach ( $settings['system_typography'] as $t ) {
+            $fonts[] = array(
+                'title'      => isset( $t['title'] ) ? $t['title'] : '',
+                'typography_font_family' => isset( $t['typography_font_family'] ) ? $t['typography_font_family'] : '',
+                'typography_font_size'   => isset( $t['typography_font_size'] ) ? $t['typography_font_size'] : '',
+                'typography_font_weight' => isset( $t['typography_font_weight'] ) ? $t['typography_font_weight'] : '',
+            );
+        }
+    }
+
+    $layout = array(
+        'container_width'        => isset( $settings['container_width'] ) ? $settings['container_width'] : array(),
+        'space_between_widgets'  => isset( $settings['space_between_widgets'] ) ? $settings['space_between_widgets'] : '',
+        'page_title_selector'    => isset( $settings['page_title_selector'] ) ? $settings['page_title_selector'] : '',
+        'viewport_lg'            => isset( $settings['viewport_lg'] ) ? $settings['viewport_lg'] : 1025,
+        'viewport_md'            => isset( $settings['viewport_md'] ) ? $settings['viewport_md'] : 768,
+    );
+
+    return array(
+        'success'  => true,
+        'kit_id'   => $kit_id,
+        'kit_title'=> $kit_post ? $kit_post->post_title : '',
+        'colors'   => $colors,
+        'fonts'    => $fonts,
+        'layout'   => $layout,
+        'raw_settings' => $settings,
+    );
+}
+
+function wsp_execute_elementor_update_active_kit( $input ) {
+    if ( ! wsp_elementor_is_active() ) {
+        return array( 'success' => false, 'error' => 'Elementor is not active.' );
+    }
+
+    $kit_id = get_option( 'elementor_active_kit' );
+    if ( ! $kit_id ) {
+        return array( 'success' => false, 'error' => 'No active Elementor kit found.' );
+    }
+
+    $settings = get_post_meta( $kit_id, '_elementor_page_settings', true );
+    if ( ! is_array( $settings ) ) {
+        $settings = array();
+    }
+
+    $updated = array();
+    $settings = wsp_elementor_sanitize_settings( $settings );
+
+    if ( isset( $input['system_colors'] ) && is_array( $input['system_colors'] ) ) {
+        $settings['system_colors'] = array();
+        foreach ( $input['system_colors'] as $c ) {
+            $settings['system_colors'][] = array(
+                '_id'   => isset( $c['_id'] ) ? sanitize_text_field( $c['_id'] ) : wsp_elementor_generate_id(),
+                'title' => isset( $c['title'] ) ? sanitize_text_field( $c['title'] ) : '',
+                'color' => isset( $c['color'] ) ? sanitize_text_field( $c['color'] ) : '',
+            );
+        }
+        $updated[] = 'system_colors';
+    }
+
+    if ( isset( $input['container_width'] ) && is_array( $input['container_width'] ) ) {
+        $settings['container_width'] = $input['container_width'];
+        $updated[] = 'container_width';
+    }
+
+    if ( isset( $input['space_between_widgets'] ) ) {
+        $settings['space_between_widgets'] = sanitize_text_field( wp_unslash( $input['space_between_widgets'] ) );
+        $updated[] = 'space_between_widgets';
+    }
+
+    if ( empty( $updated ) ) {
+        return array( 'success' => false, 'error' => 'No settings provided to update.' );
+    }
+
+    update_post_meta( $kit_id, '_elementor_page_settings', $settings );
+
+    if ( isset( \Elementor\Plugin::$instance->files_manager ) ) {
+        \Elementor\Plugin::$instance->files_manager->clear_cache();
+    }
+
+    return array(
+        'success' => true,
+        'kit_id'  => $kit_id,
+        'updated' => $updated,
+    );
+}
+
+function wsp_execute_elementor_regenerate_css( $input ) {
+    if ( ! wsp_elementor_is_active() ) {
+        return array( 'success' => false, 'error' => 'Elementor is not active.' );
+    }
+
+    try {
+        if ( isset( \Elementor\Plugin::$instance->files_manager ) ) {
+            \Elementor\Plugin::$instance->files_manager->clear_cache();
+        }
+
+        if ( class_exists( '\Elementor\Core\Files\CSS\Post' ) ) {
+            $all_pages = get_posts( array(
+                'post_type'      => array( 'page', 'post', 'elementor_library' ),
+                'posts_per_page' => -1,
+                'meta_key'       => '_elementor_edit_mode',
+                'meta_value'     => 'builder',
+                'fields'         => 'ids',
+            ) );
+            foreach ( $all_pages as $pid ) {
+                $css = new \Elementor\Core\Files\CSS\Post( $pid );
+                $css->enqueue();
+            }
+        }
+
+        return array(
+            'success' => true,
+            'message' => 'Elementor CSS cache cleared and regenerated.',
+        );
+    } catch ( Exception $e ) {
+        return array( 'success' => false, 'error' => $e->getMessage() );
+    }
+}
+
+function wsp_execute_elementor_get_widget_schema( $input ) {
+    if ( ! wsp_elementor_is_active() ) {
+        return array( 'success' => false, 'error' => 'Elementor is not active.' );
+    }
+
+    $widget_type = isset( $input['widget_type'] ) ? sanitize_text_field( wp_unslash( $input['widget_type'] ) ) : '';
+
+    if ( ! $widget_type ) {
+        return array( 'success' => false, 'error' => 'widget_type is required.' );
+    }
+
+    if ( wsp_elementor_is_blocked_widget( $widget_type ) ) {
+        return array( 'success' => false, 'error' => 'Schema not available for blocked widget types.' );
+    }
+
+    $manager = \Elementor\Plugin::$instance->widgets_manager;
+    $widget  = $manager->get_widget_types( $widget_type );
+
+    if ( ! $widget ) {
+        return array( 'success' => false, 'error' => 'Widget type not found.' );
+    }
+
+    $controls = $widget->get_controls();
+    $schema   = array(
+        'widget_type' => $widget_type,
+        'title'       => $widget->get_title(),
+        'icon'        => $widget->get_icon(),
+        'categories'  => $widget->get_categories(),
+    );
+
+    $controls_list = array();
+    $key_categories = array(
+        'content'  => array(),
+        'style'    => array(),
+        'layout'   => array(),
+        'typography' => array(),
+        'background' => array(),
+        'border'   => array(),
+        'spacing'  => array(),
+        'advanced' => array(),
+        'other'    => array(),
+    );
+
+    foreach ( $controls as $ckey => $control ) {
+        $c = array(
+            'name'        => $ckey,
+            'label'       => isset( $control['label'] ) ? $control['label'] : $ckey,
+            'type'        => isset( $control['type'] ) ? $control['type'] : '',
+            'description' => isset( $control['description'] ) ? $control['description'] : '',
+            'default'     => isset( $control['default'] ) ? $control['default'] : null,
+            'selectors'   => isset( $control['selectors'] ) ? $control['selectors'] : null,
+        );
+
+        if ( ! empty( $control['options'] ) ) {
+            $c['options'] = $control['options'];
+        }
+
+        if ( ! empty( $control['condition'] ) ) {
+            $c['condition'] = $control['condition'];
+        }
+
+        $tab = isset( $control['tab'] ) ? $control['tab'] : '';
+        if ( 'content' === $tab ) {
+            $key_categories['content'][] = $c;
+        } elseif ( 'style' === $tab ) {
+            $key_categories['style'][] = $c;
+        } else {
+            $key_categories['other'][] = $c;
+        }
+
+        $controls_list[] = $c;
+    }
+
+    $schema['controls_by_tab'] = $key_categories;
+    $schema['total_controls']  = count( $controls_list );
+    $schema['editable_properties'] = array(
+        'margins'    => array( 'margin', '_margin', 'margin_top', 'margin_right', 'margin_bottom', 'margin_left' ),
+        'padding'    => array( 'padding', '_padding', 'padding_top', 'padding_right', 'padding_bottom', 'padding_left' ),
+        'background' => array( 'background_background', 'background_color', 'background_image', 'background_gradient', 'background_overlay' ),
+        'border'     => array( 'border_border', '_border_width', '_border_radius', 'border_color' ),
+        'typography' => array( 'typography_typography', 'typography_font_family', 'typography_font_size', 'typography_font_weight', 'typography_line_height', 'typography_letter_spacing' ),
+        'layout'     => array( 'width', 'height', 'align', 'position', 'z_index' ),
+    );
+
+    return array( 'success' => true, 'schema' => $schema );
+}
+
+function wsp_elementor_clone_and_reid( $element ) {
+    $clone = $element;
+    $clone['id'] = wsp_elementor_generate_id();
+    if ( ! empty( $clone['elements'] ) && is_array( $clone['elements'] ) ) {
+        $clone['elements'] = array();
+        foreach ( $element['elements'] as $child ) {
+            $clone['elements'][] = wsp_elementor_clone_and_reid( $child );
+        }
+    }
+    return $clone;
+}
+
+function wsp_execute_elementor_duplicate_element( $input ) {
+    $post_id    = intval( $input['post_id'] );
+    $element_id = sanitize_text_field( wp_unslash( $input['element_id'] ) );
+    $parent_id  = isset( $input['parent_id'] ) ? sanitize_text_field( wp_unslash( $input['parent_id'] ) ) : null;
+    $position   = isset( $input['position'] ) ? intval( $input['position'] ) : null;
+
+    $data = wsp_elementor_get_data( $post_id );
+    if ( is_wp_error( $data ) ) return array( 'success' => false, 'error' => $data->get_error_message() );
+
+    $source = wsp_elementor_find_by_id( $data, $element_id );
+    if ( ! $source ) return array( 'success' => false, 'error' => 'Source element not found.' );
+
+    $clone = wsp_elementor_clone_and_reid( $source );
+
+    if ( $parent_id ) {
+        if ( ! wsp_elementor_insert_into( $data, $parent_id, $clone, $position ) ) {
+            return array( 'success' => false, 'error' => 'Parent element not found.' );
+        }
+    } else {
+        $parent_id = wsp_elementor_find_by_id( $data, $element_id );
+        $root_found = false;
+        foreach ( $data as $i => $root ) {
+            if ( $root['id'] === $element_id ) {
+                array_splice( $data, $i + 1, 0, array( $clone ) );
+                $root_found = true;
+                break;
+            }
+        }
+        if ( ! $root_found ) {
+            if ( null !== $position ) {
+                array_splice( $data, $position, 0, array( $clone ) );
+            } else {
+                $data[] = $clone;
+            }
+        }
+    }
+
+    wsp_elementor_save_data( $post_id, $data );
+    return array( 'success' => true, 'element_id' => $clone['id'], 'original_id' => $element_id );
+}
+
+function wsp_execute_elementor_move_element( $input ) {
+    $post_id       = intval( $input['post_id'] );
+    $element_id    = sanitize_text_field( wp_unslash( $input['element_id'] ) );
+    $new_parent_id = isset( $input['new_parent_id'] ) ? sanitize_text_field( wp_unslash( $input['new_parent_id'] ) ) : null;
+    $new_position  = isset( $input['position'] ) ? intval( $input['position'] ) : null;
+
+    $data = wsp_elementor_get_data( $post_id );
+    if ( is_wp_error( $data ) ) return array( 'success' => false, 'error' => $data->get_error_message() );
+
+    $element = wsp_elementor_find_by_id( $data, $element_id );
+    if ( ! $element ) return array( 'success' => false, 'error' => 'Element not found.' );
+
+    if ( ! wsp_elementor_remove_by_id( $data, $element_id ) ) {
+        return array( 'success' => false, 'error' => 'Failed to remove element from old position.' );
+    }
+
+    if ( $new_parent_id ) {
+        if ( ! wsp_elementor_insert_into( $data, $new_parent_id, $element, $new_position ) ) {
+            $data[] = $element;
+            return array( 'success' => false, 'error' => 'Target parent not found. Element placed at root level.' );
+        }
+    } else {
+        if ( null !== $new_position ) {
+            array_splice( $data, $new_position, 0, array( $element ) );
+        } else {
+            $data[] = $element;
+        }
+    }
+
+    wsp_elementor_save_data( $post_id, $data );
+    return array( 'success' => true, 'element_id' => $element_id, 'message' => 'Element moved successfully.' );
+}
+
+function wsp_execute_elementor_convert_css( $input ) {
+    $css_rules = isset( $input['css'] ) ? $input['css'] : array();
+    if ( ! is_array( $css_rules ) ) {
+        $css_rules = array();
+    }
+
+    $result = array();
+
+    foreach ( $css_rules as $property => $value ) {
+        $prop = strtolower( trim( $property ) );
+        $val  = trim( (string) $value );
+
+        switch ( $prop ) {
+            case 'padding':
+                $parts = preg_split( '/\s+/', $val );
+                if ( 1 === count( $parts ) ) {
+                    $unit = 'px';
+                    $num = floatval( $parts[0] );
+                    $result['_padding'] = array( 'top' => (string) $num, 'right' => (string) $num, 'bottom' => (string) $num, 'left' => (string) $num, 'unit' => $unit, 'isLinked' => true );
+                } elseif ( 2 === count( $parts ) ) {
+                    $result['_padding'] = array( 'top' => (string) floatval( $parts[0] ), 'right' => (string) floatval( $parts[1] ), 'bottom' => (string) floatval( $parts[0] ), 'left' => (string) floatval( $parts[1] ), 'unit' => 'px', 'isLinked' => false );
+                } elseif ( 4 === count( $parts ) ) {
+                    $result['_padding'] = array( 'top' => (string) floatval( $parts[0] ), 'right' => (string) floatval( $parts[1] ), 'bottom' => (string) floatval( $parts[2] ), 'left' => (string) floatval( $parts[3] ), 'unit' => 'px', 'isLinked' => false );
+                }
+                break;
+
+            case 'margin':
+                $parts = preg_split( '/\s+/', $val );
+                if ( 1 === count( $parts ) ) {
+                    $num = floatval( $parts[0] );
+                    $result['_margin'] = array( 'top' => (string) $num, 'right' => (string) $num, 'bottom' => (string) $num, 'left' => (string) $num, 'unit' => 'px', 'isLinked' => true );
+                } elseif ( 4 === count( $parts ) ) {
+                    $result['_margin'] = array( 'top' => (string) floatval( $parts[0] ), 'right' => (string) floatval( $parts[1] ), 'bottom' => (string) floatval( $parts[2] ), 'left' => (string) floatval( $parts[3] ), 'unit' => 'px', 'isLinked' => false );
+                }
+                break;
+
+            case 'border-radius':
+            case 'border_radius':
+                $num = floatval( $val );
+                $result['_border_radius'] = array( 'top' => (string) $num, 'right' => (string) $num, 'bottom' => (string) $num, 'left' => (string) $num, 'unit' => 'px', 'isLinked' => true );
+                break;
+
+            case 'border-width':
+                $num = floatval( $val );
+                $result['_border_width'] = array( 'top' => (string) $num, 'right' => (string) $num, 'bottom' => (string) $num, 'left' => (string) $num, 'unit' => 'px', 'isLinked' => true );
+                break;
+
+            case 'background-color':
+            case 'background_color':
+                $result['background_background'] = 'classic';
+                $result['background_color'] = $val;
+                break;
+
+            case 'color':
+            case 'text_color':
+                $result['title_color'] = $val;
+                break;
+
+            case 'font-size':
+            case 'font_size':
+                $num = floatval( $val );
+                $result['typography_font_size'] = array( 'unit' => 'px', 'size' => $num );
+                break;
+
+            case 'font-weight':
+            case 'font_weight':
+                $result['typography_font_weight'] = $val;
+                break;
+
+            case 'text-align':
+            case 'text_align':
+                $result['align'] = $val;
+                break;
+
+            case 'width':
+                $result['width'] = array( 'unit' => '%' === substr( $val, -1 ) ? '%' : 'px', 'size' => floatval( $val ) );
+                break;
+
+            case 'height':
+                $result['height'] = array( 'unit' => '%' === substr( $val, -1 ) ? '%' : 'px', 'size' => floatval( $val ) );
+                break;
+
+            case 'gap':
+            case 'column_gap':
+                $num = floatval( $val );
+                $result['gap'] = array( 'unit' => 'px', 'size' => $num );
+                break;
+
+            case 'border-style':
+                $result['border_border'] = $val;
+                break;
+
+            case 'border-color':
+                $result['border_color'] = $val;
+                break;
+
+            case 'opacity':
+                $result['opacity'] = array( 'unit' => '%', 'size' => floatval( $val ) * 100 );
+                break;
+
+            case 'display':
+                $result['display'] = $val;
+                break;
+
+            default:
+                $result[ $prop ] = $val;
+                break;
+        }
+    }
+
+    return array(
+        'success' => true,
+        'input_rules'  => $css_rules,
+        'elementor_settings' => $result,
+        'parsed_count' => count( $result ),
+    );
+}
+
+function wsp_execute_elementor_get_page_settings( $input ) {
+    $post_id = isset( $input['post_id'] ) ? intval( $input['post_id'] ) : 0;
+    if ( ! $post_id ) {
+        return array( 'success' => false, 'error' => 'post_id is required.' );
+    }
+
+    $settings = get_post_meta( $post_id, '_elementor_page_settings', true );
+    if ( ! is_array( $settings ) ) {
+        $settings = array();
+    }
+
+    $template = get_post_meta( $post_id, '_wp_page_template', true );
+
+    return array(
+        'success'       => true,
+        'post_id'       => $post_id,
+        'page_template' => $template ?: 'default',
+        'settings'      => $settings,
+    );
+}
+
+function wsp_execute_elementor_update_page_settings( $input ) {
+    $post_id = isset( $input['post_id'] ) ? intval( $input['post_id'] ) : 0;
+    if ( ! $post_id ) {
+        return array( 'success' => false, 'error' => 'post_id is required.' );
+    }
+
+    $updated = array();
+    $settings = get_post_meta( $post_id, '_elementor_page_settings', true );
+    if ( ! is_array( $settings ) ) {
+        $settings = array();
+    }
+
+    if ( isset( $input['page_template'] ) ) {
+        $template = sanitize_text_field( wp_unslash( $input['page_template'] ) );
+        update_post_meta( $post_id, '_wp_page_template', $template );
+
+        if ( 'elementor_canvas' === $template ) {
+            $settings['template'] = 'elementor_canvas';
+        } elseif ( 'elementor_header_footer' === $template ) {
+            $settings['template'] = 'elementor_header_footer';
+        } else {
+            $settings['template'] = 'default';
+        }
+        $updated[] = 'page_template';
+    }
+
+    if ( isset( $input['hide_title'] ) ) {
+        $settings['hide_title'] = (bool) $input['hide_title'] ? 'yes' : '';
+        $updated[] = 'hide_title';
+    }
+
+    if ( isset( $input['content_width'] ) ) {
+        $cw = isset( $input['content_width']['size'] ) ? $input['content_width'] : array( 'unit' => 'px', 'size' => floatval( $input['content_width'] ) );
+        $settings['content_width'] = $cw;
+        $updated[] = 'content_width';
+    }
+
+    if ( isset( $input['background_color'] ) ) {
+        $settings['background_background'] = 'classic';
+        $settings['background_color'] = sanitize_text_field( wp_unslash( $input['background_color'] ) );
+        $updated[] = 'background_color';
+    }
+
+    if ( isset( $input['settings'] ) && is_array( $input['settings'] ) ) {
+        $extra = wsp_elementor_sanitize_settings( $input['settings'] );
+        $settings = array_merge( $settings, $extra );
+        $updated[] = 'settings';
+    }
+
+    if ( empty( $updated ) ) {
+        return array( 'success' => false, 'error' => 'No settings provided to update.' );
+    }
+
+    update_post_meta( $post_id, '_elementor_page_settings', $settings );
+
+    return array(
+        'success' => true,
+        'post_id' => $post_id,
+        'updated' => $updated,
+    );
+}
+
+function wsp_execute_elementor_copy_styles( $input ) {
+    $post_id       = intval( $input['post_id'] );
+    $source_id     = sanitize_text_field( wp_unslash( $input['source_id'] ) );
+    $destination_id= sanitize_text_field( wp_unslash( $input['destination_id'] ) );
+    $merge         = isset( $input['merge'] ) ? (bool) $input['merge'] : false;
+
+    $data = wsp_elementor_get_data( $post_id );
+    if ( is_wp_error( $data ) ) return array( 'success' => false, 'error' => $data->get_error_message() );
+
+    $source = wsp_elementor_find_by_id( $data, $source_id );
+    if ( ! $source ) return array( 'success' => false, 'error' => 'Source element not found.' );
+
+    $dest = wsp_elementor_find_by_id( $data, $destination_id );
+    if ( ! $dest ) return array( 'success' => false, 'error' => 'Destination element not found.' );
+
+    $source_settings = isset( $source['settings'] ) ? $source['settings'] : array();
+
+    if ( $merge ) {
+        $merged = array_merge( isset( $dest['settings'] ) ? $dest['settings'] : array(), $source_settings );
+        wsp_elementor_update_by_id( $data, $destination_id, $merged );
+    } else {
+        wsp_elementor_update_by_id( $data, $destination_id, $source_settings );
+    }
+
+    wsp_elementor_save_data( $post_id, $data );
+
+    return array(
+        'success'        => true,
+        'post_id'        => $post_id,
+        'source_id'      => $source_id,
+        'destination_id' => $destination_id,
+        'merge'          => $merge,
+    );
+}
+
+function wsp_execute_elementor_get_breakpoints( $input ) {
+    if ( ! wsp_elementor_is_active() ) {
+        return array( 'success' => false, 'error' => 'Elementor is not active.' );
+    }
+
+    $kit_id = get_option( 'elementor_active_kit' );
+    $kit_settings = $kit_id ? get_post_meta( $kit_id, '_elementor_page_settings', true ) : array();
+    if ( ! is_array( $kit_settings ) ) {
+        $kit_settings = array();
+    }
+
+    $breakpoints = array(
+        'desktop' => array(
+            'label' => 'Desktop',
+            'min'   => isset( $kit_settings['viewport_lg'] ) ? intval( $kit_settings['viewport_lg'] ) : 1025,
+            'max'   => '',
+        ),
+        'tablet' => array(
+            'label' => 'Tablet',
+            'min'   => isset( $kit_settings['viewport_md'] ) ? intval( $kit_settings['viewport_md'] ) : 768,
+            'max'   => isset( $kit_settings['viewport_lg'] ) ? intval( $kit_settings['viewport_lg'] ) - 1 : 1024,
+        ),
+        'mobile' => array(
+            'label' => 'Mobile',
+            'min'   => 0,
+            'max'   => isset( $kit_settings['viewport_md'] ) ? intval( $kit_settings['viewport_md'] ) - 1 : 767,
+        ),
+        'mobile_extra' => array(
+            'label' => 'Mobile Extra',
+            'min'   => isset( $kit_settings['viewport_mobile'] ) ? intval( $kit_settings['viewport_mobile'] ) : 360,
+            'max'   => '',
+        ),
+    );
+
+    return array(
+        'success'     => true,
+        'breakpoints' => $breakpoints,
+        'description' => 'Use these breakpoints when setting responsive properties. Elementor supports _tablet and _mobile suffixes on settings keys for responsive overrides.',
+    );
+}
+>>>>>>> d108e8e (v2.6.5: CF7 + WPForms + Elementor Advanced Design Tools + all integrations)

--- a/wsp-mcp-ai-agents-connector/includes/abilities/wpforms.php
+++ b/wsp-mcp-ai-agents-connector/includes/abilities/wpforms.php
@@ -1,0 +1,774 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+if ( ! function_exists( 'wsp_wpforms_is_active' ) ) {
+function wsp_wpforms_is_active() {
+    return function_exists( 'wpforms' ) || class_exists( 'WPForms' );
+}
+}
+
+if ( ! function_exists( 'wsp_wpforms_pro_is_active' ) ) {
+function wsp_wpforms_pro_is_active() {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return false;
+    }
+    return method_exists( wpforms(), 'is_pro' ) && wpforms()->is_pro();
+}
+}
+
+// ---------------------------------------------
+// HELPERS
+// ---------------------------------------------
+
+function wsp_wpforms_get_form_data( $form_id ) {
+    $form = get_post( $form_id );
+    if ( ! $form || 'wpforms' !== $form->post_type ) {
+        return false;
+    }
+    $data = json_decode( $form->post_content, true );
+    if ( ! is_array( $data ) ) {
+        return false;
+    }
+    return $data;
+}
+
+function wsp_wpforms_save_form_data( $form_id, $data ) {
+    $data['id'] = (string) $form_id;
+    $data['field_id'] = wsp_wpforms_get_next_field_id( $data );
+    $json = wp_json_encode( $data );
+    return wp_update_post( array(
+        'ID'           => $form_id,
+        'post_content' => wp_slash( $json ),
+    ), true );
+}
+
+function wsp_wpforms_get_next_field_id( $data ) {
+    $max_id = -1;
+    if ( ! empty( $data['fields'] ) && is_array( $data['fields'] ) ) {
+        foreach ( $data['fields'] as $field ) {
+            $fid = isset( $field['id'] ) ? intval( $field['id'] ) : -1;
+            if ( $fid > $max_id ) {
+                $max_id = $fid;
+            }
+        }
+    }
+    return $max_id + 1;
+}
+
+function wsp_wpforms_field_types() {
+    return array(
+        'text'       => array( 'label' => 'Single Line Text', 'can_have_choices' => false ),
+        'textarea'   => array( 'label' => 'Paragraph Text',   'can_have_choices' => false ),
+        'select'     => array( 'label' => 'Dropdown',         'can_have_choices' => true  ),
+        'radio'      => array( 'label' => 'Multiple Choice',  'can_have_choices' => true  ),
+        'checkbox'   => array( 'label' => 'Checkboxes',       'can_have_choices' => true  ),
+        'number'     => array( 'label' => 'Numbers',          'can_have_choices' => false ),
+        'email'      => array( 'label' => 'Email',            'can_have_choices' => false ),
+        'url'        => array( 'label' => 'Website / URL',    'can_have_choices' => false ),
+        'phone'      => array( 'label' => 'Phone',            'can_have_choices' => false ),
+        'date-time'  => array( 'label' => 'Date / Time',      'can_have_choices' => false ),
+        'file-upload'=> array( 'label' => 'File Upload',      'can_have_choices' => false ),
+        'password'   => array( 'label' => 'Password',         'can_have_choices' => false ),
+        'payment-single' => array( 'label' => 'Single Item',  'can_have_choices' => false ),
+        'name'       => array( 'label' => 'Name',             'can_have_choices' => false ),
+        'address'    => array( 'label' => 'Address',          'can_have_choices' => false ),
+    );
+}
+
+// ---------------------------------------------
+// EXECUTE CALLBACKS
+// ---------------------------------------------
+
+function wsp_execute_wpforms_list_forms( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    $forms = get_posts( array(
+        'post_type'      => 'wpforms',
+        'posts_per_page' => -1,
+        'post_status'    => array( 'publish', 'draft' ),
+        'orderby'        => 'date',
+        'order'          => 'DESC',
+    ) );
+
+    $result = array();
+    foreach ( $forms as $form ) {
+        $data = json_decode( $form->post_content, true );
+        $field_count = ! empty( $data['fields'] ) && is_array( $data['fields'] ) ? count( $data['fields'] ) : 0;
+        $result[] = array(
+            'id'          => $form->ID,
+            'title'       => $form->post_title,
+            'date'        => $form->post_date,
+            'status'      => $form->post_status,
+            'field_count' => $field_count,
+        );
+    }
+
+    return array( 'forms' => $result, 'total' => count( $result ) );
+}
+
+function wsp_execute_wpforms_get_form( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    $form_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $form_id ) {
+        return array( 'success' => false, 'error' => 'Form ID is required.' );
+    }
+
+    $form = get_post( $form_id );
+    if ( ! $form || 'wpforms' !== $form->post_type ) {
+        return array( 'success' => false, 'error' => 'Form not found.' );
+    }
+
+    $data = json_decode( $form->post_content, true );
+    if ( ! is_array( $data ) ) {
+        $data = array();
+    }
+
+    return array(
+        'success'     => true,
+        'id'          => $form->ID,
+        'title'       => $form->post_title,
+        'date'        => $form->post_date,
+        'status'      => $form->post_status,
+        'shortcode'   => sprintf( '[wpforms id="%d"]', $form->ID ),
+        'fields'      => isset( $data['fields'] ) ? $data['fields'] : array(),
+        'settings'    => isset( $data['settings'] ) ? $data['settings'] : array(),
+        'payments'    => isset( $data['payments'] ) ? $data['payments'] : array(),
+        'field_count' => isset( $data['fields'] ) && is_array( $data['fields'] ) ? count( $data['fields'] ) : 0,
+    );
+}
+
+function wsp_execute_wpforms_describe_schema( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    $types = wsp_wpforms_field_types();
+    $field_types = array();
+
+    foreach ( $types as $slug => $info ) {
+        $entry = array(
+            'type'             => $slug,
+            'label'            => $info['label'],
+            'can_have_choices' => $info['can_have_choices'],
+            'editable_attrs'   => array( 'label', 'description', 'required', 'css' ),
+        );
+        if ( $info['can_have_choices'] ) {
+            $entry['editable_attrs'][] = 'choices';
+        }
+        $field_types[] = $entry;
+    }
+
+    $form_settings = array(
+        'form_title'       => 'string — Form title (stored as post_title)',
+        'form_desc'        => 'string — Form description',
+        'submit_text'      => 'string — Submit button text',
+        'submit_processing'=> 'string — Text shown while processing',
+        'antispam'         => 'boolean — Enable anti-spam honeypot',
+        'ajax_submit'      => 'boolean — Enable AJAX form submission',
+        'notification_email'=> 'string — Email for notifications',
+    );
+
+    return array(
+        'success'      => true,
+        'field_types'  => $field_types,
+        'total_types'  => count( $field_types ),
+        'form_settings'=> $form_settings,
+        'notes'        => array(
+            'Field IDs are auto-assigned as incremental integers (0, 1, 2...).',
+            'Choice-based fields (select, radio, checkbox) require a \"choices\" array with \"label\" and \"value\" keys.',
+            'Form data is stored as JSON in the wpforms post_type post_content.',
+        ),
+    );
+}
+
+function wsp_execute_wpforms_get_form_stats( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    $form_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+
+    $total_forms = count( get_posts( array(
+        'post_type'      => 'wpforms',
+        'posts_per_page' => -1,
+        'post_status'    => 'any',
+        'fields'         => 'ids',
+    ) ) );
+
+    $stats = array(
+        'total_forms'       => $total_forms,
+        'entries_available' => false,
+    );
+
+    if ( wsp_wpforms_pro_is_active() && isset( wpforms()->entry ) ) {
+        $stats['entries_available'] = true;
+
+        $entry_handler = wpforms()->get( 'entry' );
+        if ( $entry_handler && method_exists( $entry_handler, 'get_entries_count' ) ) {
+            $args = array();
+            if ( $form_id ) {
+                $args['form_id'] = $form_id;
+            }
+            $stats['total_entries'] = $entry_handler->get_entries_count( $args );
+        }
+
+        if ( $form_id ) {
+            $form = get_post( $form_id );
+            if ( $form && 'wpforms' === $form->post_type ) {
+                $data = json_decode( $form->post_content, true );
+                $stats['form_id']    = $form_id;
+                $stats['form_title'] = $form->post_title;
+                $stats['form_status'] = $form->post_status;
+                $stats['field_count'] = ! empty( $data['fields'] ) && is_array( $data['fields'] ) ? count( $data['fields'] ) : 0;
+            }
+        }
+
+        if ( ! $form_id ) {
+            $forms = get_posts( array(
+                'post_type'        => 'wpforms',
+                'posts_per_page'   => 5,
+                'post_status'      => 'publish',
+                'orderby'          => 'date',
+                'order'            => 'DESC',
+            ) );
+            $recent = array();
+            foreach ( $forms as $f ) {
+                $f_args = array( 'form_id' => $f->ID );
+                $count = $entry_handler->get_entries_count( $f_args );
+                $recent[] = array(
+                    'id'          => $f->ID,
+                    'title'       => $f->post_title,
+                    'entry_count' => $count,
+                );
+            }
+            $stats['recent_forms'] = $recent;
+        }
+    } else {
+        $stats['message'] = 'Entry statistics require WPForms Pro.';
+    }
+
+    return array(
+        'success' => true,
+        'stats'   => $stats,
+    );
+}
+
+function wsp_execute_wpforms_create_form( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    $title = isset( $input['title'] ) ? sanitize_text_field( wp_unslash( $input['title'] ) ) : '';
+    if ( ! $title ) {
+        return array( 'success' => false, 'error' => 'Form title is required.' );
+    }
+
+    $desc        = isset( $input['description'] ) ? sanitize_textarea_field( wp_unslash( $input['description'] ) ) : '';
+    $fields      = isset( $input['fields'] ) ? $input['fields'] : array();
+    $submit_text = isset( $input['submit_text'] ) ? sanitize_text_field( wp_unslash( $input['submit_text'] ) ) : 'Submit';
+    $notify_email= isset( $input['notification_email'] ) ? sanitize_email( wp_unslash( $input['notification_email'] ) ) : '{admin_email}';
+    $notify_subject= isset( $input['notification_subject'] ) ? sanitize_text_field( wp_unslash( $input['notification_subject'] ) ) : 'New Entry: ' . $title;
+
+    $form_data = array(
+        'fields'   => array(),
+        'settings' => array(
+            'form_title'              => $title,
+            'form_desc'               => $desc,
+            'form_class'              => '',
+            'submit_text'             => $submit_text,
+            'submit_text_processing'  => 'Sending...',
+            'antispam'                => '1',
+            'ajax_submit'             => '1',
+            'notification_enable'     => '1',
+            'notifications'           => array(
+                '1' => array(
+                    'email'          => $notify_email,
+                    'subject'        => $notify_subject,
+                    'sender_name'    => get_bloginfo( 'name' ),
+                    'sender_address' => '{admin_email}',
+                    'replyto'        => '{field_id="1"}',
+                    'message'        => '{all_fields}',
+                ),
+            ),
+            'confirmations' => array(
+                '1' => array(
+                    'type'    => 'message',
+                    'message' => '<p>Thanks for contacting us! We will be in touch with you shortly.</p>',
+                ),
+            ),
+        ),
+    );
+
+    if ( ! empty( $fields ) && is_array( $fields ) ) {
+        foreach ( $fields as $idx => $f ) {
+            $fid = intval( $idx );
+            $field = array(
+                'id'    => $fid,
+                'type'  => isset( $f['type'] ) ? sanitize_text_field( $f['type'] ) : 'text',
+                'label' => isset( $f['label'] ) ? sanitize_text_field( $f['label'] ) : '',
+            );
+            if ( ! empty( $f['required'] ) ) {
+                $field['required'] = '1';
+            }
+            if ( ! empty( $f['description'] ) ) {
+                $field['description'] = sanitize_textarea_field( $f['description'] );
+            }
+            if ( ! empty( $f['choices'] ) && is_array( $f['choices'] ) ) {
+                $field['choices'] = array();
+                foreach ( $f['choices'] as $cidx => $choice ) {
+                    $field['choices'][] = array(
+                        'label' => sanitize_text_field( isset( $choice['label'] ) ? $choice['label'] : $choice ),
+                        'value' => sanitize_text_field( isset( $choice['value'] ) ? $choice['value'] : $choice ),
+                    );
+                }
+            }
+            if ( ! empty( $f['placeholder'] ) ) {
+                $field['placeholder'] = sanitize_text_field( $f['placeholder'] );
+            }
+            $form_data['fields'][ $fid ] = $field;
+        }
+    }
+
+    $form_id = wp_insert_post( array(
+        'post_type'    => 'wpforms',
+        'post_title'   => $title,
+        'post_content' => '',
+        'post_status'  => 'publish',
+    ), true );
+
+    if ( is_wp_error( $form_id ) ) {
+        return array( 'success' => false, 'error' => $form_id->get_error_message() );
+    }
+
+    $form_data['id']       = (string) $form_id;
+    $form_data['field_id'] = count( $form_data['fields'] );
+    $json = wp_json_encode( $form_data );
+    wp_update_post( array(
+        'ID'           => $form_id,
+        'post_content' => wp_slash( $json ),
+    ) );
+
+    return array(
+        'success'   => true,
+        'id'        => $form_id,
+        'title'     => $title,
+        'shortcode' => sprintf( '[wpforms id="%d"]', $form_id ),
+    );
+}
+
+function wsp_execute_wpforms_update_form_settings( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    $form_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $form_id ) {
+        return array( 'success' => false, 'error' => 'Form ID is required.' );
+    }
+
+    $form = get_post( $form_id );
+    if ( ! $form || 'wpforms' !== $form->post_type ) {
+        return array( 'success' => false, 'error' => 'Form not found.' );
+    }
+
+    $data = json_decode( $form->post_content, true );
+    if ( ! is_array( $data ) ) {
+        $data = array( 'fields' => array(), 'settings' => array() );
+    }
+    if ( ! isset( $data['settings'] ) ) {
+        $data['settings'] = array();
+    }
+
+    $updated = array();
+    $settings_map = array(
+        'title'                 => 'form_title',
+        'description'           => 'form_desc',
+        'submit_text'           => 'submit_text',
+        'submit_text_processing'=> 'submit_text_processing',
+        'antispam'              => 'antispam',
+        'ajax_submit'           => 'ajax_submit',
+    );
+
+    if ( isset( $input['title'] ) ) {
+        $new_title = sanitize_text_field( wp_unslash( $input['title'] ) );
+        wp_update_post( array( 'ID' => $form_id, 'post_title' => $new_title ) );
+        $updated[] = 'title';
+    }
+
+    foreach ( $settings_map as $input_key => $data_key ) {
+        if ( ! isset( $input[ $input_key ] ) ) {
+            continue;
+        }
+        if ( in_array( $input_key, array( 'antispam', 'ajax_submit' ), true ) ) {
+            $data['settings'][ $data_key ] = (bool) $input[ $input_key ] ? '1' : '';
+        } elseif ( 'description' === $input_key ) {
+            $data['settings'][ $data_key ] = sanitize_textarea_field( wp_unslash( $input[ $input_key ] ) );
+        } else {
+            $data['settings'][ $data_key ] = sanitize_text_field( wp_unslash( $input[ $input_key ] ) );
+        }
+        $updated[] = $input_key;
+    }
+
+    if ( empty( $updated ) ) {
+        return array( 'success' => false, 'error' => 'No settings provided to update.' );
+    }
+
+    $result = wsp_wpforms_save_form_data( $form_id, $data );
+    if ( is_wp_error( $result ) ) {
+        return array( 'success' => false, 'error' => $result->get_error_message() );
+    }
+
+    return array(
+        'success' => true,
+        'id'      => $form_id,
+        'updated' => $updated,
+    );
+}
+
+function wsp_execute_wpforms_add_field( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    $form_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $form_id ) {
+        return array( 'success' => false, 'error' => 'Form ID is required.' );
+    }
+
+    $data = wsp_wpforms_get_form_data( $form_id );
+    if ( ! $data ) {
+        return array( 'success' => false, 'error' => 'Form not found.' );
+    }
+
+    $field_type = isset( $input['type'] ) ? sanitize_text_field( wp_unslash( $input['type'] ) ) : 'text';
+    $types = wsp_wpforms_field_types();
+    if ( ! isset( $types[ $field_type ] ) ) {
+        return array( 'success' => false, 'error' => 'Invalid field type. Use wpforms-describe-schema to see available types.' );
+    }
+
+    $label = isset( $input['label'] ) ? sanitize_text_field( wp_unslash( $input['label'] ) ) : '';
+    if ( ! $label ) {
+        return array( 'success' => false, 'error' => 'Field label is required.' );
+    }
+
+    if ( ! isset( $data['fields'] ) ) {
+        $data['fields'] = array();
+    }
+
+    $new_id = wsp_wpforms_get_next_field_id( $data );
+    $field = array(
+        'id'    => $new_id,
+        'type'  => $field_type,
+        'label' => $label,
+    );
+
+    if ( ! empty( $input['required'] ) ) {
+        $field['required'] = '1';
+    }
+    if ( ! empty( $input['description'] ) ) {
+        $field['description'] = sanitize_textarea_field( wp_unslash( $input['description'] ) );
+    }
+    if ( ! empty( $input['placeholder'] ) ) {
+        $field['placeholder'] = sanitize_text_field( wp_unslash( $input['placeholder'] ) );
+    }
+    if ( ! empty( $input['css'] ) ) {
+        $field['css'] = sanitize_text_field( wp_unslash( $input['css'] ) );
+    }
+
+    if ( $types[ $field_type ]['can_have_choices'] && ! empty( $input['choices'] ) && is_array( $input['choices'] ) ) {
+        $field['choices'] = array();
+        foreach ( $input['choices'] as $choice ) {
+            $field['choices'][] = array(
+                'label' => sanitize_text_field( isset( $choice['label'] ) ? $choice['label'] : $choice ),
+                'value' => sanitize_text_field( isset( $choice['value'] ) ? $choice['value'] : $choice ),
+            );
+        }
+    }
+
+    $data['fields'][ $new_id ] = $field;
+
+    $result = wsp_wpforms_save_form_data( $form_id, $data );
+    if ( is_wp_error( $result ) ) {
+        return array( 'success' => false, 'error' => $result->get_error_message() );
+    }
+
+    return array(
+        'success'   => true,
+        'form_id'   => $form_id,
+        'field_id'  => $new_id,
+        'field'     => $field,
+    );
+}
+
+function wsp_execute_wpforms_update_field( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    $form_id  = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    $field_id = isset( $input['field_id'] ) ? sanitize_text_field( wp_unslash( $input['field_id'] ) ) : '';
+    if ( ! $form_id || '' === $field_id ) {
+        return array( 'success' => false, 'error' => 'Form ID and Field ID are required.' );
+    }
+
+    $data = wsp_wpforms_get_form_data( $form_id );
+    if ( ! $data ) {
+        return array( 'success' => false, 'error' => 'Form not found.' );
+    }
+
+    if ( ! isset( $data['fields'][ $field_id ] ) ) {
+        return array( 'success' => false, 'error' => 'Field not found.' );
+    }
+
+    $field = &$data['fields'][ $field_id ];
+    $updated = array();
+
+    $updatable = array( 'label', 'description', 'placeholder', 'css' );
+    foreach ( $updatable as $attr ) {
+        if ( isset( $input[ $attr ] ) ) {
+            if ( 'description' === $attr ) {
+                $field[ $attr ] = sanitize_textarea_field( wp_unslash( $input[ $attr ] ) );
+            } else {
+                $field[ $attr ] = sanitize_text_field( wp_unslash( $input[ $attr ] ) );
+            }
+            $updated[] = $attr;
+        }
+    }
+
+    if ( isset( $input['required'] ) ) {
+        $field['required'] = (bool) $input['required'] ? '1' : '';
+        $updated[] = 'required';
+    }
+
+    if ( isset( $input['choices'] ) && is_array( $input['choices'] ) ) {
+        $field['choices'] = array();
+        foreach ( $input['choices'] as $choice ) {
+            $field['choices'][] = array(
+                'label' => sanitize_text_field( isset( $choice['label'] ) ? $choice['label'] : $choice ),
+                'value' => sanitize_text_field( isset( $choice['value'] ) ? $choice['value'] : $choice ),
+            );
+        }
+        $updated[] = 'choices';
+    }
+
+    if ( empty( $updated ) ) {
+        return array( 'success' => false, 'error' => 'No fields to update provided.' );
+    }
+
+    $result = wsp_wpforms_save_form_data( $form_id, $data );
+    if ( is_wp_error( $result ) ) {
+        return array( 'success' => false, 'error' => $result->get_error_message() );
+    }
+
+    return array(
+        'success'  => true,
+        'form_id'  => $form_id,
+        'field_id' => $field_id,
+        'updated'  => $updated,
+    );
+}
+
+function wsp_execute_wpforms_delete_form( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    $form_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $form_id ) {
+        return array( 'success' => false, 'error' => 'Form ID is required.' );
+    }
+
+    $form = get_post( $form_id );
+    if ( ! $form || 'wpforms' !== $form->post_type ) {
+        return array( 'success' => false, 'error' => 'Form not found.' );
+    }
+
+    $permanent = isset( $input['permanent'] ) ? (bool) $input['permanent'] : false;
+
+    if ( $permanent ) {
+        $result = wp_delete_post( $form_id, true );
+        if ( ! $result ) {
+            return array( 'success' => false, 'error' => 'Failed to permanently delete form.' );
+        }
+    } else {
+        $result = wp_trash_post( $form_id );
+        if ( ! $result ) {
+            return array( 'success' => false, 'error' => 'Failed to move form to trash.' );
+        }
+    }
+
+    return array(
+        'success' => true,
+        'message' => $permanent ? 'Form permanently deleted.' : 'Form moved to trash.',
+        'id'      => $form_id,
+    );
+}
+
+function wsp_execute_wpforms_list_entries( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    if ( ! wsp_wpforms_pro_is_active() ) {
+        return array( 'success' => false, 'error' => 'WPForms Pro is required for entry storage. Please upgrade to WPForms Pro.' );
+    }
+
+    $entry_handler = wpforms()->get( 'entry' );
+    if ( ! $entry_handler ) {
+        return array( 'success' => false, 'error' => 'Entry system is not available.' );
+    }
+
+    $form_id  = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    $per_page = isset( $input['per_page'] ) ? intval( $input['per_page'] ) : 20;
+    $page     = isset( $input['page'] ) ? intval( $input['page'] ) : 1;
+    $status   = isset( $input['status'] ) ? sanitize_text_field( wp_unslash( $input['status'] ) ) : '';
+
+    $args = array(
+        'number' => $per_page,
+        'offset' => ( $page - 1 ) * $per_page,
+        'order'  => 'DESC',
+    );
+
+    if ( $form_id ) {
+        $args['form_id'] = $form_id;
+    }
+
+    if ( $status && 'all' !== $status ) {
+        $args['entry_status'] = $status;
+    }
+
+    $entries = $entry_handler->get_entries( $args );
+    $total = $entry_handler->get_entries_count( $args );
+
+    $items = array();
+    if ( is_array( $entries ) ) {
+        foreach ( $entries as $entry ) {
+            $items[] = array(
+                'entry_id'    => $entry->entry_id,
+                'form_id'     => $entry->form_id,
+                'date'        => $entry->date,
+                'status'      => isset( $entry->status ) ? $entry->status : 'publish',
+                'starred'     => ! empty( $entry->starred ),
+                'viewed'      => ! empty( $entry->viewed ),
+            );
+        }
+    }
+
+    return array(
+        'entries'  => $items,
+        'total'    => (int) $total,
+        'page'     => $page,
+        'per_page' => $per_page,
+    );
+}
+
+function wsp_execute_wpforms_get_entry( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    if ( ! wsp_wpforms_pro_is_active() ) {
+        return array( 'success' => false, 'error' => 'WPForms Pro is required for entry storage. Please upgrade to WPForms Pro.' );
+    }
+
+    $entry_handler = wpforms()->get( 'entry' );
+    if ( ! $entry_handler ) {
+        return array( 'success' => false, 'error' => 'Entry system is not available.' );
+    }
+
+    $entry_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $entry_id ) {
+        return array( 'success' => false, 'error' => 'Entry ID is required.' );
+    }
+
+    $entry = $entry_handler->get( $entry_id );
+    if ( ! $entry ) {
+        return array( 'success' => false, 'error' => 'Entry not found.' );
+    }
+
+    $fields = array();
+    if ( method_exists( $entry_handler, 'get_entry_fields' ) ) {
+        $entry_fields = $entry_handler->get_entry_fields( array(
+            'entry_id' => $entry_id,
+            'number'   => -1,
+        ) );
+        if ( is_array( $entry_fields ) ) {
+            foreach ( $entry_fields as $ef ) {
+                $fields[] = array(
+                    'field_id' => $ef->field_id,
+                    'label'    => sanitize_text_field( isset( $ef->field_label ) ? $ef->field_label : '' ),
+                    'value'    => $ef->value,
+                    'type'     => isset( $ef->type ) ? $ef->type : '',
+                );
+            }
+        }
+    }
+
+    $form_title = '';
+    if ( $entry->form_id ) {
+        $form_post = get_post( $entry->form_id );
+        if ( $form_post ) {
+            $form_title = $form_post->post_title;
+        }
+    }
+
+    return array(
+        'success'    => true,
+        'entry_id'   => $entry->entry_id,
+        'form_id'    => $entry->form_id,
+        'form_title' => $form_title,
+        'date'       => $entry->date,
+        'status'     => isset( $entry->status ) ? $entry->status : 'publish',
+        'starred'    => ! empty( $entry->starred ),
+        'viewed'     => ! empty( $entry->viewed ),
+        'user_ip'    => isset( $entry->ip_address ) ? $entry->ip_address : '',
+        'user_agent' => isset( $entry->user_agent ) ? $entry->user_agent : '',
+        'fields'     => $fields,
+    );
+}
+
+function wsp_execute_wpforms_delete_entry( $input ) {
+    if ( ! function_exists( 'wpforms' ) ) {
+        return array( 'success' => false, 'error' => 'WPForms is not active.' );
+    }
+
+    if ( ! wsp_wpforms_pro_is_active() ) {
+        return array( 'success' => false, 'error' => 'WPForms Pro is required for entry storage. Please upgrade to WPForms Pro.' );
+    }
+
+    $entry_handler = wpforms()->get( 'entry' );
+    if ( ! $entry_handler ) {
+        return array( 'success' => false, 'error' => 'Entry system is not available.' );
+    }
+
+    $entry_id = isset( $input['id'] ) ? intval( $input['id'] ) : 0;
+    if ( ! $entry_id ) {
+        return array( 'success' => false, 'error' => 'Entry ID is required.' );
+    }
+
+    $entry = $entry_handler->get( $entry_id );
+    if ( ! $entry ) {
+        return array( 'success' => false, 'error' => 'Entry not found.' );
+    }
+
+    $permanent = isset( $input['permanent'] ) ? (bool) $input['permanent'] : false;
+
+    if ( $permanent && method_exists( $entry_handler, 'delete' ) ) {
+        $entry_handler->delete( $entry_id );
+    } elseif ( method_exists( $entry_handler, 'update_status' ) ) {
+        $entry_handler->update_status( $entry_id, 'trash' );
+    } else {
+        return array( 'success' => false, 'error' => 'Entry deletion is not supported in this version of WPForms.' );
+    }
+
+    return array(
+        'success'  => true,
+        'message'  => $permanent ? 'Entry permanently deleted.' : 'Entry moved to trash.',
+        'entry_id' => $entry_id,
+    );
+}

--- a/wsp-mcp-ai-agents-connector/includes/admin/settings-page.php
+++ b/wsp-mcp-ai-agents-connector/includes/admin/settings-page.php
@@ -188,6 +188,8 @@ function wsp_mcp_settings_page() {
         'WooCommerce'            => '🛍️',
         'Advanced Custom Fields'    => '🧩',
         'Gravity Forms'             => '📋',
+        'Contact Form 7'           => '📬',
+        'WPForms'                  => '📊',
     );
     $total   = count( $settings );
     $enabled = count( array_filter( $settings ) );

--- a/wsp-mcp-ai-agents-connector/includes/registry.php
+++ b/wsp-mcp-ai-agents-connector/includes/registry.php
@@ -32,6 +32,17 @@ if ( ! function_exists( 'wsp_gravity_is_active' ) ) {
     }
 }
 
+if ( ! function_exists( 'wsp_cf7_is_active' ) ) {
+    function wsp_cf7_is_active() {
+        return class_exists( 'WPCF7_ContactForm' );
+    }
+}
+
+if ( ! function_exists( 'wsp_wpforms_is_active' ) ) {
+    function wsp_wpforms_is_active() {
+        return function_exists( 'wpforms' ) || class_exists( 'WPForms' );
+    }
+}
 
 function wsp_mcp_ability_registry() {
     $abilities = array(
@@ -121,6 +132,17 @@ function wsp_mcp_ability_registry() {
             'wsp/elementor-add-widget'     => array( 'label' => 'Add Widget',            'description' => 'Add a widget to a container or column on an Elementor page.',              'group' => 'Elementor', 'access' => 'write', 'default' => false ),
             'wsp/elementor-add-container'  => array( 'label' => 'Add Container',         'description' => 'Add a layout container or section to an Elementor page.',                  'group' => 'Elementor', 'access' => 'write', 'default' => false ),
             'wsp/elementor-remove-element' => array( 'label' => 'Remove Element',        'description' => 'Remove a widget or container from an Elementor page by element ID.',       'group' => 'Elementor', 'access' => 'write', 'default' => false ),
+            'wsp/elementor-get-active-kit'     => array( 'label' => 'Get Active Kit',       'description' => 'Retrieve global fonts, color palette, and layout from the active Elementor kit.', 'group' => 'Elementor', 'access' => 'read',  'default' => false ),
+            'wsp/elementor-update-active-kit'  => array( 'label' => 'Update Active Kit',    'description' => 'Update colors and layout settings in the active Elementor kit.',            'group' => 'Elementor', 'access' => 'write', 'default' => false ),
+            'wsp/elementor-regenerate-css'     => array( 'label' => 'Regenerate CSS',       'description' => 'Clear and regenerate all Elementor CSS cache files.',                      'group' => 'Elementor', 'access' => 'write', 'default' => false ),
+            'wsp/elementor-get-widget-schema'  => array( 'label' => 'Get Widget Schema',    'description' => 'Get control schema for a widget type — margins, padding, background, typography, etc.', 'group' => 'Elementor', 'access' => 'read',  'default' => false ),
+            'wsp/elementor-duplicate-element'  => array( 'label' => 'Duplicate Element',    'description' => 'Clone a widget or container with new unique IDs recursively.',              'group' => 'Elementor', 'access' => 'write', 'default' => false ),
+            'wsp/elementor-move-element'       => array( 'label' => 'Move Element',         'description' => 'Reposition an element to a different parent or index position.',           'group' => 'Elementor', 'access' => 'write', 'default' => false ),
+            'wsp/elementor-convert-css'        => array( 'label' => 'Convert CSS to Elementor', 'description' => 'Parse CSS rules into Elementor-compatible settings structure.',            'group' => 'Elementor', 'access' => 'read',  'default' => false ),
+            'wsp/elementor-get-page-settings'  => array( 'label' => 'Get Page Settings',    'description' => 'Read global page config like template, background, and custom CSS.',       'group' => 'Elementor', 'access' => 'read',  'default' => false ),
+            'wsp/elementor-update-page-settings'=> array( 'label' => 'Update Page Settings', 'description' => 'Update page template (canvas/full-width) and page-level settings.',        'group' => 'Elementor', 'access' => 'write', 'default' => false ),
+            'wsp/elementor-copy-styles'        => array( 'label' => 'Copy Element Styles',   'description' => 'Copy style settings from a source element to a destination element.',     'group' => 'Elementor', 'access' => 'write', 'default' => false ),
+            'wsp/elementor-get-breakpoints'    => array( 'label' => 'Get Breakpoints',      'description' => 'Read responsive breakpoint values from Elementor configuration.',          'group' => 'Elementor', 'access' => 'read',  'default' => false ),
         );
     }
 
@@ -232,6 +254,39 @@ function wsp_mcp_ability_registry() {
         );
     }
 
+    if ( wsp_cf7_is_active() ) {
+        $cf7_g = 'Contact Form 7';
+        $abilities += array(
+            'wsp/cf7-list-forms'       => array( 'label' => 'List CF7 Forms',           'description' => 'Lists all Contact Form 7 forms with ID, title, and shortcode.',                         'group' => $cf7_g, 'access' => 'read',  'default' => true  ),
+            'wsp/cf7-get-form'         => array( 'label' => 'Get CF7 Form',             'description' => 'Retrieves full CF7 form structure (markup, mail config, messages, tags).',             'group' => $cf7_g, 'access' => 'read',  'default' => true  ),
+            'wsp/cf7-create-form'      => array( 'label' => 'Create CF7 Form',          'description' => 'Creates a new Contact Form 7 form with title and optional markup/properties.',          'group' => $cf7_g, 'access' => 'write', 'default' => false ),
+            'wsp/cf7-update-form'      => array( 'label' => 'Update CF7 Form',          'description' => 'Updates an existing CF7 form markup, mail settings, or messages.',                      'group' => $cf7_g, 'access' => 'write', 'default' => false ),
+            'wsp/cf7-delete-form'      => array( 'label' => 'Delete CF7 Form',          'description' => 'Trashes or permanently deletes a Contact Form 7 form.',                                 'group' => $cf7_g, 'access' => 'write', 'default' => false ),
+            'wsp/cf7-list-entries'     => array( 'label' => 'List CF7 Entries',         'description' => 'Lists Flamingo-stored form submissions (requires Flamingo plugin).',                    'group' => $cf7_g, 'access' => 'read',  'default' => false ),
+            'wsp/cf7-get-entry'        => array( 'label' => 'Get CF7 Entry',            'description' => 'Retrieves full details of a single Flamingo submission by ID.',                         'group' => $cf7_g, 'access' => 'read',  'default' => false ),
+            'wsp/cf7-validate-form'    => array( 'label' => 'Validate CF7 Form',        'description' => 'Runs the built-in configuration validator to check for email/syntax errors.',          'group' => $cf7_g, 'access' => 'read',  'default' => false ),
+            'wsp/cf7-get-integrations' => array( 'label' => 'Get CF7 Integrations',     'description' => 'Lists active integration modules and reCAPTCHA configuration status.',                  'group' => $cf7_g, 'access' => 'read',  'default' => false ),
+            'wsp/cf7-moderate-entry'   => array( 'label' => 'Moderate CF7 Entry',       'description' => 'Mark a Flamingo submission as spam, unspam, trash, or untrash.',                        'group' => $cf7_g, 'access' => 'write', 'default' => false ),
+        );
+    }
+
+    if ( wsp_wpforms_is_active() ) {
+        $wpf_g = 'WPForms';
+        $abilities += array(
+            'wsp/wpforms-list-forms'         => array( 'label' => 'List WPForms',           'description' => 'Lists all WPForms with ID, title, date, status, and field count.',              'group' => $wpf_g, 'access' => 'read',  'default' => true  ),
+            'wsp/wpforms-get-form'           => array( 'label' => 'Get Form',               'description' => 'Retrieves full WPForms structure (fields, settings, payments config).',     'group' => $wpf_g, 'access' => 'read',  'default' => true  ),
+            'wsp/wpforms-describe-schema'    => array( 'label' => 'Describe Schema',        'description' => 'Returns supported field types and editable attributes to guide AI.',            'group' => $wpf_g, 'access' => 'read',  'default' => true  ),
+            'wsp/wpforms-get-form-stats'     => array( 'label' => 'Get Form Stats',         'description' => 'Fetch entry counts and analytics for forms (Pro entry stats).',                'group' => $wpf_g, 'access' => 'read',  'default' => true  ),
+            'wsp/wpforms-create-form'        => array( 'label' => 'Create Form',            'description' => 'Creates a new WPForms form with fields, settings, and notifications.',        'group' => $wpf_g, 'access' => 'write', 'default' => false ),
+            'wsp/wpforms-update-form-settings'=> array( 'label' => 'Update Form Settings',   'description' => 'Update form settings (title, description, submit text, AJAX, anti-spam).',    'group' => $wpf_g, 'access' => 'write', 'default' => false ),
+            'wsp/wpforms-add-field'          => array( 'label' => 'Add Field',              'description' => 'Add a new field to an existing form with auto-assigned ID.',                  'group' => $wpf_g, 'access' => 'write', 'default' => false ),
+            'wsp/wpforms-update-field'       => array( 'label' => 'Update Field',           'description' => 'Update a field\'s label, description, required status, or choices.',          'group' => $wpf_g, 'access' => 'write', 'default' => false ),
+            'wsp/wpforms-delete-form'        => array( 'label' => 'Delete Form',            'description' => 'Trashes or permanently deletes a WPForms form.',                              'group' => $wpf_g, 'access' => 'write', 'default' => false ),
+            'wsp/wpforms-list-entries'       => array( 'label' => 'List Entries',           'description' => 'Lists submission entries for a form (requires WPForms Pro).',                 'group' => $wpf_g, 'access' => 'read',  'default' => false ),
+            'wsp/wpforms-get-entry'          => array( 'label' => 'Get Entry',              'description' => 'Retrieves full details and field values of a single entry.',                  'group' => $wpf_g, 'access' => 'read',  'default' => false ),
+            'wsp/wpforms-delete-entry'       => array( 'label' => 'Delete Entry',           'description' => 'Trashes or permanently deletes a submission entry (Pro).',                    'group' => $wpf_g, 'access' => 'write', 'default' => false ),
+        );
+    }
     return $abilities;
 }
 

--- a/wsp-mcp-ai-agents-connector/includes/tools/native-tools.php
+++ b/wsp-mcp-ai-agents-connector/includes/tools/native-tools.php
@@ -637,6 +637,118 @@ function wsp_mcp_register_native_tools() {
 			'capability'  => 'edit_posts',
 			'enable_key'  => 'wsp/elementor-remove-element',
 		) );
+
+		// -- Advanced Design Tools (v2.6.5) --
+		WSP_MCP_Server::register_tool( 'wsp_elementor_get_active_kit', array(
+			'description' => 'Retrieve global fonts, color palette, and layout from the active Elementor kit.',
+			'inputSchema' => $obj,
+			'callback'    => 'wsp_execute_elementor_get_active_kit',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/elementor-get-active-kit',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_elementor_update_active_kit', array(
+			'description' => 'Update colors and layout settings in the active Elementor kit.',
+			'inputSchema' => array( 'type' => 'object', 'properties' => array(
+				'system_colors'           => array( 'type' => 'array', 'items' => array( 'type' => 'object' ), 'description' => 'Array of {title, color, _id} color objects.' ),
+				'container_width'         => array( 'type' => 'object', 'description' => 'Container width setting object.' ),
+				'space_between_widgets'   => array( 'type' => 'string', 'description' => 'Space between widgets value.' ),
+			) ),
+			'callback'    => 'wsp_execute_elementor_update_active_kit',
+			'capability'  => 'manage_options',
+			'enable_key'  => 'wsp/elementor-update-active-kit',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_elementor_regenerate_css', array(
+			'description' => 'Clear and regenerate all Elementor CSS cache files.',
+			'inputSchema' => $obj,
+			'callback'    => 'wsp_execute_elementor_regenerate_css',
+			'capability'  => 'manage_options',
+			'enable_key'  => 'wsp/elementor-regenerate-css',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_elementor_get_widget_schema', array(
+			'description' => 'Get control schema for a widget type — margins, padding, background, typography, etc.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'widget_type' ), 'properties' => array(
+				'widget_type' => array( 'type' => 'string', 'description' => 'Elementor widget slug (e.g. heading, button, image, text-editor).' ),
+			) ),
+			'callback'    => 'wsp_execute_elementor_get_widget_schema',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/elementor-get-widget-schema',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_elementor_duplicate_element', array(
+			'description' => 'Clone a widget or container with new unique IDs recursively.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'post_id', 'element_id' ), 'properties' => array(
+				'post_id'    => array( 'type' => 'integer' ),
+				'element_id' => array( 'type' => 'string' ),
+				'parent_id'  => array( 'type' => 'string', 'description' => 'Optional parent to place the clone into.' ),
+				'position'   => array( 'type' => 'integer', 'description' => 'Optional insertion position.' ),
+			) ),
+			'callback'    => 'wsp_execute_elementor_duplicate_element',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/elementor-duplicate-element',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_elementor_move_element', array(
+			'description' => 'Reposition an element to a different parent or index position.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'post_id', 'element_id' ), 'properties' => array(
+				'post_id'       => array( 'type' => 'integer' ),
+				'element_id'    => array( 'type' => 'string' ),
+				'new_parent_id' => array( 'type' => 'string', 'description' => 'Target parent element ID (null = root).' ),
+				'position'      => array( 'type' => 'integer', 'description' => 'Target index position.' ),
+			) ),
+			'callback'    => 'wsp_execute_elementor_move_element',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/elementor-move-element',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_elementor_convert_css', array(
+			'description' => 'Parse CSS rules into Elementor-compatible settings structure.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'css' ), 'properties' => array(
+				'css' => array( 'type' => 'object', 'description' => 'CSS key-value map (e.g. {"padding": "20px 10px", "background-color": "#ff0000"}).' ),
+			) ),
+			'callback'    => 'wsp_execute_elementor_convert_css',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/elementor-convert-css',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_elementor_get_page_settings', array(
+			'description' => 'Read global page config like template, background, and custom CSS.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'post_id' ), 'properties' => array(
+				'post_id' => array( 'type' => 'integer' ),
+			) ),
+			'callback'    => 'wsp_execute_elementor_get_page_settings',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/elementor-get-page-settings',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_elementor_update_page_settings', array(
+			'description' => 'Update page template (canvas/full-width) and page-level settings.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'post_id' ), 'properties' => array(
+				'post_id'          => array( 'type' => 'integer' ),
+				'page_template'    => array( 'type' => 'string', 'description' => 'elementor_canvas | elementor_header_footer | default.' ),
+				'hide_title'       => array( 'type' => 'boolean', 'description' => 'Hide page title.' ),
+				'content_width'    => array( 'type' => 'object', 'description' => 'Content width {unit, size}.' ),
+				'background_color' => array( 'type' => 'string', 'description' => 'Page background color.' ),
+				'settings'         => array( 'type' => 'object', 'description' => 'Additional page settings to merge.' ),
+			) ),
+			'callback'    => 'wsp_execute_elementor_update_page_settings',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/elementor-update-page-settings',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_elementor_copy_styles', array(
+			'description' => 'Copy style settings from a source element to a destination element.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'post_id', 'source_id', 'destination_id' ), 'properties' => array(
+				'post_id'        => array( 'type' => 'integer' ),
+				'source_id'      => array( 'type' => 'string', 'description' => 'Element ID to copy styles from.' ),
+				'destination_id' => array( 'type' => 'string', 'description' => 'Element ID to apply styles to.' ),
+				'merge'          => array( 'type' => 'boolean', 'description' => 'Merge with existing settings (true) or overwrite (false). Default: false.' ),
+			) ),
+			'callback'    => 'wsp_execute_elementor_copy_styles',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/elementor-copy-styles',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_elementor_get_breakpoints', array(
+			'description' => 'Read responsive breakpoint values from Elementor configuration.',
+			'inputSchema' => $obj,
+			'callback'    => 'wsp_execute_elementor_get_breakpoints',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/elementor-get-breakpoints',
+		) );
+	}
 	}
 
 	// ---- Advanced Custom Fields (only when ACF is active) ----
@@ -1214,6 +1326,248 @@ function wsp_mcp_register_native_tools() {
 			'callback'    => 'wsp_execute_gravity_update_form_settings',
 			'capability'  => 'gravityforms_edit_forms',
 			'enable_key'  => 'wsp/gravity-update-form-settings',
+		) );
+	}
+
+	// ---- Contact Form 7 (only when CF7 is active) ----
+	if ( function_exists( 'wsp_cf7_is_active' ) && wsp_cf7_is_active() ) {
+		WSP_MCP_Server::register_tool( 'wsp_cf7_list_forms', array(
+			'description' => 'Lists all Contact Form 7 forms with ID, title, and shortcode.',
+			'inputSchema' => $obj,
+			'callback'    => 'wsp_execute_cf7_list_forms',
+			'capability'  => 'wpcf7_edit_contact_forms',
+			'enable_key'  => 'wsp/cf7-list-forms',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_cf7_get_form', array(
+			'description' => 'Retrieves full CF7 form structure (markup, mail config, messages, tags).',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id' => array( 'type' => 'integer', 'description' => 'Form ID.' ),
+			) ),
+			'callback'    => 'wsp_execute_cf7_get_form',
+			'capability'  => 'wpcf7_edit_contact_forms',
+			'enable_key'  => 'wsp/cf7-get-form',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_cf7_create_form', array(
+			'description' => 'Creates a new Contact Form 7 form with title and optional markup/properties.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'title' ), 'properties' => array(
+				'title'       => array( 'type' => 'string', 'description' => 'Form title.' ),
+				'locale'      => array( 'type' => 'string', 'description' => 'Locale code (e.g. en_US).' ),
+				'form_markup' => array( 'type' => 'string', 'description' => 'Custom form markup HTML.' ),
+				'mail'        => array( 'type' => 'object', 'description' => 'Mail settings key-value pairs.' ),
+				'messages'    => array( 'type' => 'object', 'description' => 'Custom messages key-value pairs.' ),
+			) ),
+			'callback'    => 'wsp_execute_cf7_create_form',
+			'capability'  => 'wpcf7_edit_contact_forms',
+			'enable_key'  => 'wsp/cf7-create-form',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_cf7_update_form', array(
+			'description' => 'Updates an existing CF7 form markup, mail settings, or messages.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id'                   => array( 'type' => 'integer', 'description' => 'Form ID.' ),
+				'title'                => array( 'type' => 'string', 'description' => 'New form title.' ),
+				'locale'               => array( 'type' => 'string', 'description' => 'Locale code.' ),
+				'form_markup'          => array( 'type' => 'string', 'description' => 'Updated form markup.' ),
+				'mail'                 => array( 'type' => 'object', 'description' => 'Updated mail settings.' ),
+				'mail_2'               => array( 'type' => 'object', 'description' => 'Updated mail (2) settings.' ),
+				'messages'             => array( 'type' => 'object', 'description' => 'Updated messages.' ),
+				'additional_settings'  => array( 'type' => 'string', 'description' => 'Additional settings text.' ),
+			) ),
+			'callback'    => 'wsp_execute_cf7_update_form',
+			'capability'  => 'wpcf7_edit_contact_forms',
+			'enable_key'  => 'wsp/cf7-update-form',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_cf7_delete_form', array(
+			'description' => 'Trashes or permanently deletes a Contact Form 7 form.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id'        => array( 'type' => 'integer', 'description' => 'Form ID.' ),
+				'permanent' => array( 'type' => 'boolean', 'description' => 'True for permanent delete, false to move to trash. Default false.' ),
+			) ),
+			'callback'    => 'wsp_execute_cf7_delete_form',
+			'capability'  => 'wpcf7_delete_contact_forms',
+			'enable_key'  => 'wsp/cf7-delete-form',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_cf7_list_entries', array(
+			'description' => 'Lists Flamingo-stored form submissions (requires Flamingo plugin).',
+			'inputSchema' => array( 'type' => 'object', 'properties' => array(
+				'form_id'  => array( 'type' => 'integer', 'description' => 'Form ID to filter by.' ),
+				'per_page' => array( 'type' => 'integer', 'description' => 'Number of entries. Default 20.' ),
+				'page'     => array( 'type' => 'integer', 'description' => 'Page number. Default 1.' ),
+				'status'   => array( 'type' => 'string', 'description' => 'publish | spam | trash | all.' ),
+			) ),
+			'callback'    => 'wsp_execute_cf7_list_entries',
+			'capability'  => 'wpcf7_edit_contact_forms',
+			'enable_key'  => 'wsp/cf7-list-entries',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_cf7_get_entry', array(
+			'description' => 'Retrieves full details of a single Flamingo submission by ID.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id' => array( 'type' => 'integer', 'description' => 'Entry ID.' ),
+			) ),
+			'callback'    => 'wsp_execute_cf7_get_entry',
+			'capability'  => 'wpcf7_edit_contact_forms',
+			'enable_key'  => 'wsp/cf7-get-entry',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_cf7_validate_form', array(
+			'description' => 'Runs the built-in configuration validator to check for email/syntax errors.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id' => array( 'type' => 'integer', 'description' => 'Form ID.' ),
+			) ),
+			'callback'    => 'wsp_execute_cf7_validate_form',
+			'capability'  => 'wpcf7_edit_contact_forms',
+			'enable_key'  => 'wsp/cf7-validate-form',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_cf7_get_integrations', array(
+			'description' => 'Lists active integration modules and reCAPTCHA configuration status.',
+			'inputSchema' => $obj,
+			'callback'    => 'wsp_execute_cf7_get_integrations',
+			'capability'  => 'manage_options',
+			'enable_key'  => 'wsp/cf7-get-integrations',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_cf7_moderate_entry', array(
+			'description' => 'Mark a Flamingo submission as spam, unspam, trash, or untrash.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id', 'action' ), 'properties' => array(
+				'id'     => array( 'type' => 'integer', 'description' => 'Entry ID.' ),
+				'action' => array( 'type' => 'string', 'description' => 'spam | unspam | trash | untrash.' ),
+			) ),
+			'callback'    => 'wsp_execute_cf7_moderate_entry',
+			'capability'  => 'wpcf7_edit_contact_forms',
+			'enable_key'  => 'wsp/cf7-moderate-entry',
+		) );
+	}
+
+	// ---- WPForms (only when WPForms is active) ----
+	if ( function_exists( 'wsp_wpforms_is_active' ) && wsp_wpforms_is_active() ) {
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_list_forms', array(
+			'description' => 'Lists all WPForms with ID, title, date, status, and field count.',
+			'inputSchema' => $obj,
+			'callback'    => 'wsp_execute_wpforms_list_forms',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-list-forms',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_get_form', array(
+			'description' => 'Retrieves full WPForms structure (fields, settings, payments).',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id' => array( 'type' => 'integer', 'description' => 'Form ID.' ),
+			) ),
+			'callback'    => 'wsp_execute_wpforms_get_form',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-get-form',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_describe_schema', array(
+			'description' => 'Returns supported field types and editable attributes to guide AI on create/update field actions.',
+			'inputSchema' => $obj,
+			'callback'    => 'wsp_execute_wpforms_describe_schema',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-describe-schema',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_get_form_stats', array(
+			'description' => 'Fetch entry counts and analytics (Pro entry stats).',
+			'inputSchema' => array( 'type' => 'object', 'properties' => array(
+				'id' => array( 'type' => 'integer', 'description' => 'Form ID (optional; omit for global stats).' ),
+			) ),
+			'callback'    => 'wsp_execute_wpforms_get_form_stats',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-get-form-stats',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_create_form', array(
+			'description' => 'Creates a new WPForms form with fields, settings, and notification email.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'title' ), 'properties' => array(
+				'title'       => array( 'type' => 'string', 'description' => 'Form title.' ),
+				'description' => array( 'type' => 'string', 'description' => 'Form description.' ),
+				'fields'      => array( 'type' => 'array', 'items' => array( 'type' => 'object' ), 'description' => 'Array of field objects.' ),
+				'submit_text' => array( 'type' => 'string', 'description' => 'Submit button text. Default: Submit.' ),
+			) ),
+			'callback'    => 'wsp_execute_wpforms_create_form',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-create-form',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_update_form_settings', array(
+			'description' => 'Update form settings (title, description, submit text, AJAX, anti-spam).',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id'                     => array( 'type' => 'integer', 'description' => 'Form ID.' ),
+				'title'                  => array( 'type' => 'string', 'description' => 'Form title.' ),
+				'description'            => array( 'type' => 'string', 'description' => 'Form description.' ),
+				'submit_text'            => array( 'type' => 'string', 'description' => 'Submit button text.' ),
+				'submit_text_processing' => array( 'type' => 'string', 'description' => 'Text shown while submitting.' ),
+				'antispam'               => array( 'type' => 'boolean', 'description' => 'Enable anti-spam honeypot.' ),
+				'ajax_submit'            => array( 'type' => 'boolean', 'description' => 'Enable AJAX submission.' ),
+			) ),
+			'callback'    => 'wsp_execute_wpforms_update_form_settings',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-update-form-settings',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_add_field', array(
+			'description' => 'Add a new field to an existing form with auto-assigned ID.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id', 'type', 'label' ), 'properties' => array(
+				'id'          => array( 'type' => 'integer', 'description' => 'Form ID.' ),
+				'type'        => array( 'type' => 'string', 'description' => 'Field type (use wpforms-describe-schema to see options).' ),
+				'label'       => array( 'type' => 'string', 'description' => 'Field label.' ),
+				'required'    => array( 'type' => 'boolean', 'description' => 'Make field required.' ),
+				'description' => array( 'type' => 'string', 'description' => 'Field description text.' ),
+				'placeholder' => array( 'type' => 'string', 'description' => 'Placeholder text.' ),
+				'css'         => array( 'type' => 'string', 'description' => 'CSS class.' ),
+				'choices'     => array( 'type' => 'array', 'items' => array( 'type' => 'object' ), 'description' => 'Array of {label, value} for choice fields.' ),
+			) ),
+			'callback'    => 'wsp_execute_wpforms_add_field',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-add-field',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_update_field', array(
+			'description' => 'Update a field label, description, required status, or choices.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id', 'field_id' ), 'properties' => array(
+				'id'          => array( 'type' => 'integer', 'description' => 'Form ID.' ),
+				'field_id'    => array( 'type' => 'string', 'description' => 'Field ID (e.g. "0", "1").' ),
+				'label'       => array( 'type' => 'string', 'description' => 'Field label.' ),
+				'required'    => array( 'type' => 'boolean', 'description' => 'Make field required.' ),
+				'description' => array( 'type' => 'string', 'description' => 'Field description.' ),
+				'placeholder' => array( 'type' => 'string', 'description' => 'Placeholder text.' ),
+				'css'         => array( 'type' => 'string', 'description' => 'CSS class.' ),
+				'choices'     => array( 'type' => 'array', 'items' => array( 'type' => 'object' ), 'description' => 'Array of {label, value} for choice fields.' ),
+			) ),
+			'callback'    => 'wsp_execute_wpforms_update_field',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-update-field',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_delete_form', array(
+			'description' => 'Trashes or permanently deletes a WPForms form.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id'        => array( 'type' => 'integer', 'description' => 'Form ID.' ),
+				'permanent' => array( 'type' => 'boolean', 'description' => 'True for permanent deletion. Default false.' ),
+			) ),
+			'callback'    => 'wsp_execute_wpforms_delete_form',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-delete-form',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_list_entries', array(
+			'description' => 'Lists submission entries for a form (requires WPForms Pro).',
+			'inputSchema' => array( 'type' => 'object', 'properties' => array(
+				'id'       => array( 'type' => 'integer', 'description' => 'Form ID to filter by.' ),
+				'per_page' => array( 'type' => 'integer', 'description' => 'Number of entries. Default 20.' ),
+				'page'     => array( 'type' => 'integer', 'description' => 'Page number. Default 1.' ),
+				'status'   => array( 'type' => 'string', 'description' => 'publish | trash | all.' ),
+			) ),
+			'callback'    => 'wsp_execute_wpforms_list_entries',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-list-entries',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_get_entry', array(
+			'description' => 'Retrieves full details and field values of a single entry.',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id' => array( 'type' => 'integer', 'description' => 'Entry ID.' ),
+			) ),
+			'callback'    => 'wsp_execute_wpforms_get_entry',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-get-entry',
+		) );
+		WSP_MCP_Server::register_tool( 'wsp_wpforms_delete_entry', array(
+			'description' => 'Trashes or permanently deletes a submission entry (Pro).',
+			'inputSchema' => array( 'type' => 'object', 'required' => array( 'id' ), 'properties' => array(
+				'id'        => array( 'type' => 'integer', 'description' => 'Entry ID.' ),
+				'permanent' => array( 'type' => 'boolean', 'description' => 'True for permanent deletion. Default false.' ),
+			) ),
+			'callback'    => 'wsp_execute_wpforms_delete_entry',
+			'capability'  => 'edit_posts',
+			'enable_key'  => 'wsp/wpforms-delete-entry',
 		) );
 	}
 

--- a/wsp-mcp-ai-agents-connector/readme.txt
+++ b/wsp-mcp-ai-agents-connector/readme.txt
@@ -4,7 +4,7 @@ Tags: mcp, ai, claude, model context protocol, woocommerce
 Requires at least: 6.9
 Tested up to: 7.0.1
 Requires PHP: 7.4
-Stable tag: 2.6.2
+Stable tag: 2.6.5
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/wsp-mcp-ai-agents-connector/wsp-mcp-ai-agents-connector.php
+++ b/wsp-mcp-ai-agents-connector/wsp-mcp-ai-agents-connector.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WSP MCP - AI Agents Connector
  * Description: Exposes WordPress content to Claude AI and other AI Agents via a built-in MCP server (no companion plugin required). Manage all abilities from Settings > MCP.
- * Version: 2.6.2
+ * Version: 2.6.5
  * Requires at least: 6.9
  * Requires PHP: 7.4
  * Author: WebSensePro
@@ -14,7 +14,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'WSP_MCP_VERSION', '2.6.2' );
+define( 'WSP_MCP_VERSION', '2.6.5' );
 define( 'WSP_MCP_OPTION', 'wsp_mcp_abilities' );
 define( 'WSP_MCP_DIR', plugin_dir_path( __FILE__ ) );
 
@@ -42,6 +42,8 @@ require_once WSP_MCP_DIR . 'includes/abilities/woocommerce.php';
 require_once WSP_MCP_DIR . 'includes/abilities/acf.php'; // Included ACF Pro Abilities
 require_once WSP_MCP_DIR . 'includes/abilities/uae.php'; // Included UAE Abilities
 require_once WSP_MCP_DIR . 'includes/abilities/gravityforms.php'; // Included Gravity Forms Abilities
+require_once WSP_MCP_DIR . 'includes/abilities/cf7.php'; // Included Contact Form 7 Abilities
+require_once WSP_MCP_DIR . 'includes/abilities/wpforms.php'; // Included WPForms Abilities
 
 add_action( 'admin_menu',                       'wsp_mcp_add_menu' );
 add_action( 'admin_init',                       'wsp_mcp_register_settings' );


### PR DESCRIPTION
Added three new plugin integrations and a set of advanced Elementor design tools (11 tools) to the native MCP server.
---

## What's included

### Contact Form 7 (`v2.6.3`) — 10 tools
- **Forms:** list (ON), get (ON), create, update, delete (trash/permanent)
- **Entries (Flamingo):** list, get — requires `class_exists('Flamingo_Inbound_Message')`
- **Validation:** `validate-form` — built-in `WPCF7_ConfigValidator` checks email/syntax errors
- **Integrations:** `get-integrations` — active modules + reCAPTCHA key status (`manage_options`)
- **Moderation:** `moderate-entry` — spam/unspam/trash/untrash a Flamingo submission

### WPForms (`v2.6.4`) — 12 tools
- **Forms:** list (ON), get (ON), describe-schema (ON), get-form-stats (ON), create, update-settings, add-field, update-field, delete
- **Entries (Pro only):** list, get, delete — requires `wpforms()->is_pro()`
- Auto-assigned integer field IDs, 16 supported field types in schema description, auto-generated notification emails

### Elementor Advanced Design Tools (`v2.6.5`) — 11 tools
- `get-active-kit` / `update-active-kit` — global fonts, colors, container width, spacing
- `regenerate-css` — clear & regenerate Elementor CSS cache
- `get-widget-schema` — full control schema per widget type (margins, padding, typography, borders)
- `duplicate-element` / `move-element` — clone (recursive ID reassignment) and reposition elements
- `convert-css` — CSS shorthand → Elementor settings mapper
- `get-page-settings` / `update-page-settings` — page-level template, background, content width
- `copy-styles` — copy element settings with optional merge
- `get-breakpoints` — responsive breakpoint values from active kit