### PR TITLE
Add direct (base64) file upload for media — fixes #17

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ These three files give you complete project understanding without touching the c
 ## What this plugin is
 
 **Plugin Name:** WSP MCP - AI Agents Connector  
-**Version:** 2.6.5
+**Version:** 2.6.6
 **Slug/prefix:** `wsp`  
 **WP option key:** `wsp_mcp_abilities`  
 **Constant prefix:** `WSP_MCP_`
@@ -187,7 +187,7 @@ wsp-wordpress-mcp/                        ← repo root (NOT the plugin — dev 
 
 | Constant | Value |
 |---|---|
-| `WSP_MCP_VERSION` | `'2.6.5'` |
+| `WSP_MCP_VERSION` | `'2.6.6'` |
 | `WSP_MCP_OPTION` | `'wsp_mcp_abilities'` (per-ability on/off toggles) |
 | `WSP_MCP_DIR` | `plugin_dir_path(__FILE__)` |
 
@@ -301,11 +301,11 @@ admin toggle for each is driven by its entry in `wsp_mcp_ability_registry()` (`r
 | `wsp/count-media` | Count Media | read | OFF | `upload_files` | — (counts grouped by MIME type + total) |
 | `wsp/update-media` | Update Media | write | OFF | `upload_files` | `id` (req), `title`, `alt`, `caption`, `description` |
 | `wsp/delete-media` | Delete Media | write | OFF | `delete_posts` | `id` (req) — permanent `wp_delete_attachment()` |
-| `wsp/upload-media` | Upload Media | write | OFF | `upload_files` | `url` (req), `filename`, `title`, `alt`, `caption`, `post_id` |
+| `wsp/upload-media` | Upload Media | write | OFF | `upload_files` | **`data`** (base64) *or* `url` (one req), `mime_type`, `filename`, `title`, `alt`, `caption`, `post_id` |
 | `wsp/upload-media-from-url` | Upload Media From URL | write | OFF | `upload_files` | `url` (req), `filename`, `title`, `alt`, `caption`, `post_id` |
 
 - `wsp/get-media` returns the full metadata of a **single** attachment by ID (browse/search moved to `wsp/list-media`).
-- Uploads sideload via `download_url()` + `media_handle_sideload()` (requires `wp-admin/includes/{file,media,image}.php`, loaded inside the callback). `wsp_execute_upload_media()` is a thin wrapper over `wsp_execute_upload_media_from_url()`.
+- Uploads sideload via `download_url()` (URL path) or `wp_tempnam()` + `file_put_contents()` (base64 path), then `media_handle_sideload()` (requires `wp-admin/includes/{file,media,image}.php`, loaded inside the callback). `wsp_execute_upload_media()` routes to `wsp_execute_upload_media_from_data()` when a non-empty `data` (base64) input is present, otherwise to `wsp_execute_upload_media_from_url()`. The base64 path (v2.6.6, fixes #17) strips an optional `data:<mime>;base64,` prefix, normalizes URL-safe base64, strictly validates via `base64_decode(..., true)`, and infers the extension from `filename`/`mime_type`/data-URI. Both paths accept only image types (jpg, png, gif, webp).
 - `wsp_media_item_data()` is the shared normalizer used by get/update/upload responses.
 
 #### Users (`users.php`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [2.6.6] — 2026-07-27
+
+### Added — Direct (base64) file upload for media (`includes/abilities/media.php`, `includes/tools/native-tools.php`, `includes/registry.php`)
+- **`wsp_upload_media` now accepts base64 file content**, so an MCP client can upload a file attached to the chat **directly** into the media library — no public URL required. Fixes GitHub issue #17 ("still can't upload it directly"). Previously the only path was `url`, forcing users to host the image somewhere (e.g. Google Drive) first.
+  - New optional inputs on `wsp_upload_media`: `data` (base64 string; a `data:<mime>;base64,` prefix is accepted and stripped) and `mime_type` (used to infer the extension when `data` has no data-URI prefix and `filename` has no extension). `url` is now optional — pass **either** `data` **or** `url`; `data` wins if both are present.
+  - New callback `wsp_execute_upload_media_from_data()` in `media.php`: normalizes URL-safe/whitespaced base64, `base64_decode(..., true)` with strict validation, resolves a safe filename with an allowed image extension, writes the bytes to a `wp_tempnam()` temp file, and sideloads through `media_handle_sideload()` (same `upload_mimes` / `wp_check_filetype_and_ext` filters as the URL uploader). `wsp_execute_upload_media()` is no longer a thin wrapper — it routes to the base64 path when `data` is present, otherwise to `wsp_execute_upload_media_from_url()`.
+  - **Security unchanged:** still requires `upload_files`; only image types (jpg, jpeg, png, gif, webp) are accepted; temp files are cleaned up on failure. No other tool, callback, or file behavior was modified.
+
 ## [2.6.5] — 2026-07-21
 
 ### Added — Elementor Advanced Design Tools (`includes/abilities/elementor.php`, `includes/tools/native-tools.php`, `includes/registry.php`)

--- a/wsp-mcp-ai-agents-connector/includes/abilities/media.php
+++ b/wsp-mcp-ai-agents-connector/includes/abilities/media.php
@@ -224,10 +224,136 @@ function wsp_execute_upload_media_from_url( $input ) {
 }
 
 /**
- * Upload an image or file from a URL directly into the media library.
- * Thin wrapper around the shared sideload implementation.
+ * Decode base64 file content and sideload it into the media library.
+ * Lets an MCP client upload a file attached to the chat directly, without
+ * first hosting it at a public URL.
+ *
+ * Accepts:
+ *   - data      (req) base64 string; a `data:<mime>;base64,` prefix is stripped if present.
+ *   - filename  optional destination filename (extension inferred from mime/data URI if missing).
+ *   - mime_type optional MIME type hint (e.g. image/png) when there is no data URI prefix.
+ *   - title / alt / caption / post_id  same as the URL uploader.
+ */
+function wsp_execute_upload_media_from_data( $input ) {
+    // Undo any slashing a transport/client may have added (e.g. `image\/png`, `\/` in the payload).
+    $raw = isset( $input['data'] ) ? trim( wp_unslash( (string) $input['data'] ) ) : '';
+    if ( '' === $raw ) {
+        return array( 'success' => false, 'error' => 'Base64 "data" is required.' );
+    }
+
+    // Pull the MIME type out of a data URI prefix if one is present.
+    $mime = ! empty( $input['mime_type'] ) ? sanitize_mime_type( $input['mime_type'] ) : '';
+    if ( preg_match( '#^data:([\w.+/-]+);base64,#i', $raw, $m ) ) {
+        if ( '' === $mime ) {
+            $mime = sanitize_mime_type( $m[1] );
+        }
+        $raw = substr( $raw, strlen( $m[0] ) );
+    }
+
+    // Normalize: URL-safe base64 -> standard, then drop whitespace/newlines and any
+    // stray non-alphabet characters so strict decoding doesn't trip over them.
+    $raw     = strtr( trim( $raw ), '-_', '+/' );
+    $raw     = preg_replace( '#[^A-Za-z0-9+/=]#', '', (string) $raw );
+    $decoded = base64_decode( $raw, true );
+    if ( false === $decoded || '' === $decoded ) {
+        return array( 'success' => false, 'error' => 'The "data" value is not valid base64 (it may have been truncated or altered in transit — try a smaller image, or use "url" instead).' );
+    }
+
+    // Map allowed MIME types to extensions.
+    $mime_to_ext = array(
+        'image/jpeg' => 'jpg',
+        'image/jpg'  => 'jpg',
+        'image/png'  => 'png',
+        'image/gif'  => 'gif',
+        'image/webp' => 'webp',
+    );
+
+    // Resolve a safe filename with an allowed image extension.
+    $name = ! empty( $input['filename'] ) ? sanitize_file_name( $input['filename'] ) : '';
+    if ( $name && ! preg_match( '/\.(jpg|jpeg|png|gif|webp)$/i', $name ) ) {
+        $name = ''; // Extension not allowed/known — fall through to derive one.
+    }
+    if ( '' === $name ) {
+        $ext  = isset( $mime_to_ext[ $mime ] ) ? $mime_to_ext[ $mime ] : '';
+        if ( '' === $ext ) {
+            return array( 'success' => false, 'error' => 'Could not determine the file type. Provide a "filename" with a .jpg/.png/.gif/.webp extension or a "mime_type".' );
+        }
+        $name = 'upload-' . time() . '.' . $ext;
+    }
+
+    require_once ABSPATH . 'wp-admin/includes/file.php';
+    require_once ABSPATH . 'wp-admin/includes/media.php';
+    require_once ABSPATH . 'wp-admin/includes/image.php';
+
+    // Write the decoded bytes to a temp file for media_handle_sideload().
+    $tmp = wp_tempnam( $name );
+    if ( ! $tmp ) {
+        return array( 'success' => false, 'error' => 'Could not create a temporary file for the upload.' );
+    }
+    if ( false === file_put_contents( $tmp, $decoded ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+        wp_delete_file( $tmp );
+        return array( 'success' => false, 'error' => 'Could not write the decoded file to disk.' );
+    }
+
+    $file_array = array( 'name' => $name, 'tmp_name' => $tmp );
+    $post_id    = isset( $input['post_id'] ) ? intval( $input['post_id'] ) : 0;
+
+    $mime_filter = function( $mimes ) {
+        $mimes['jpg|jpeg|jpe'] = 'image/jpeg';
+        $mimes['png']  = 'image/png';
+        $mimes['gif']  = 'image/gif';
+        $mimes['webp'] = 'image/webp';
+        return $mimes;
+    };
+
+    $filetype_filter = function( $checked, $file, $filename, $mimes ) {
+        if ( empty( $checked['type'] ) ) {
+            $filetype_info   = wp_check_filetype( $filename, $mimes );
+            $checked['type'] = $filetype_info['type'];
+            $checked['ext']  = $filetype_info['ext'];
+        }
+        return $checked;
+    };
+
+    add_filter( 'upload_mimes', $mime_filter );
+    add_filter( 'wp_check_filetype_and_ext', $filetype_filter, 10, 4 );
+
+    $id = media_handle_sideload( $file_array, $post_id );
+
+    remove_filter( 'upload_mimes', $mime_filter );
+    remove_filter( 'wp_check_filetype_and_ext', $filetype_filter, 10, 4 );
+
+    if ( is_wp_error( $id ) ) {
+        if ( file_exists( $tmp ) ) {
+            wp_delete_file( $tmp );
+        }
+        return array( 'success' => false, 'error' => $id->get_error_message() );
+    }
+
+    $update = array( 'ID' => $id );
+    if ( ! empty( $input['title'] ) )   $update['post_title']   = sanitize_text_field( wp_unslash( $input['title'] ) );
+    if ( ! empty( $input['caption'] ) ) $update['post_excerpt'] = sanitize_text_field( wp_unslash( $input['caption'] ) );
+    if ( count( $update ) > 1 ) {
+        wp_update_post( $update );
+    }
+    if ( ! empty( $input['alt'] ) ) {
+        update_post_meta( $id, '_wp_attachment_image_alt', sanitize_text_field( wp_unslash( $input['alt'] ) ) );
+    }
+
+    return array( 'success' => true, 'id' => $id, 'url' => wp_get_attachment_url( $id ), 'media' => wsp_media_item_data( $id ) );
+}
+
+/**
+ * Upload an image or file into the media library.
+ *
+ * Accepts EITHER base64 file content in "data" (a file attached to the chat,
+ * uploaded directly with no public URL needed) OR a source "url". If both are
+ * present, "data" wins.
  */
 function wsp_execute_upload_media( $input ) {
+    if ( isset( $input['data'] ) && '' !== trim( (string) $input['data'] ) ) {
+        return wsp_execute_upload_media_from_data( $input );
+    }
     return wsp_execute_upload_media_from_url( $input );
 }
 

--- a/wsp-mcp-ai-agents-connector/includes/registry.php
+++ b/wsp-mcp-ai-agents-connector/includes/registry.php
@@ -71,7 +71,7 @@ function wsp_mcp_ability_registry() {
         'wsp/count-media'           => array( 'label' => 'Count Media',          'description' => 'Get media library counts grouped by MIME type, plus a total.',             'group' => 'Media', 'access' => 'read',  'default' => false ),
         'wsp/update-media'          => array( 'label' => 'Update Media',         'description' => 'Update the title, alt text, caption, or description of a media file by ID.', 'group' => 'Media', 'access' => 'write', 'default' => false ),
         'wsp/delete-media'          => array( 'label' => 'Delete Media',         'description' => 'Permanently delete a media file from the media library by ID.',            'group' => 'Media', 'access' => 'write', 'default' => false ),
-        'wsp/upload-media'          => array( 'label' => 'Upload Media',         'description' => 'Upload an image or file from a URL directly into the media library.',       'group' => 'Media', 'access' => 'write', 'default' => false ),
+        'wsp/upload-media'          => array( 'label' => 'Upload Media',         'description' => 'Upload an image into the media library from base64 file content (attach a file directly in chat) or a URL.',       'group' => 'Media', 'access' => 'write', 'default' => false ),
         'wsp/upload-media-from-url' => array( 'label' => 'Upload Media From URL', 'description' => 'Pull an image from any web link straight into your media library.',         'group' => 'Media', 'access' => 'write', 'default' => false ),
         'wsp/set-featured-image'    => array( 'label' => 'Set Featured Image',    'description' => 'Set an image as the featured image (thumbnail) for a post or page.',        'group' => 'Media', 'access' => 'write', 'default' => false ),
         // USERS

--- a/wsp-mcp-ai-agents-connector/includes/tools/native-tools.php
+++ b/wsp-mcp-ai-agents-connector/includes/tools/native-tools.php
@@ -234,14 +234,16 @@ function wsp_mcp_register_native_tools() {
 		'enable_key'  => 'wsp/delete-media',
 	) );
 	WSP_MCP_Server::register_tool( 'wsp_upload_media', array(
-		'description' => 'Upload an image or file from a URL directly into the WordPress media library.',
-		'inputSchema' => array( 'type' => 'object', 'required' => array( 'url' ), 'properties' => array(
-			'url'      => array( 'type' => 'string', 'description' => 'Source URL of the file to upload.' ),
-			'filename' => array( 'type' => 'string', 'description' => 'Optional destination filename.' ),
-			'title'    => array( 'type' => 'string' ),
-			'alt'      => array( 'type' => 'string' ),
-			'caption'  => array( 'type' => 'string' ),
-			'post_id'  => array( 'type' => 'integer', 'description' => 'Optional post ID to attach the media to.' ),
+		'description' => 'Upload an image into the WordPress media library. Provide EITHER "data" (base64-encoded file content — use this to upload a file attached to the chat directly, no public URL required) OR "url" (a public link to fetch). Supported types: jpg, png, gif, webp.',
+		'inputSchema' => array( 'type' => 'object', 'properties' => array(
+			'data'      => array( 'type' => 'string', 'description' => 'Base64-encoded file content. A "data:<mime>;base64," prefix is accepted. Use this to upload a file straight from the chat without a URL.' ),
+			'mime_type' => array( 'type' => 'string', 'description' => 'MIME type of the base64 data (e.g. image/png), used when "data" has no data-URI prefix and "filename" has no extension.' ),
+			'url'       => array( 'type' => 'string', 'description' => 'Source URL of the file to upload (used only when "data" is not provided).' ),
+			'filename'  => array( 'type' => 'string', 'description' => 'Optional destination filename.' ),
+			'title'     => array( 'type' => 'string' ),
+			'alt'       => array( 'type' => 'string' ),
+			'caption'   => array( 'type' => 'string' ),
+			'post_id'   => array( 'type' => 'integer', 'description' => 'Optional post ID to attach the media to.' ),
 		) ),
 		'callback'    => 'wsp_execute_upload_media',
 		'capability'  => 'upload_files',

--- a/wsp-mcp-ai-agents-connector/readme.txt
+++ b/wsp-mcp-ai-agents-connector/readme.txt
@@ -4,7 +4,7 @@ Tags: mcp, ai, claude, model context protocol, woocommerce
 Requires at least: 6.9
 Tested up to: 7.0.1
 Requires PHP: 7.4
-Stable tag: 2.6.5
+Stable tag: 2.6.6
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -144,6 +144,9 @@ Watch the step-by-step video tutorial:
 https://youtu.be/hxhjs3IUYQE
 
 == Changelog ==
+
+= 2.6.6 =
+* New: Direct file upload for media. `wsp_upload_media` (Upload Media) now accepts base64 file content via a new `data` parameter — an MCP client can upload a file attached to the chat straight into the media library without first hosting it at a public URL. The `url` parameter still works as before; pass either one. An optional `mime_type` hint and `data:` URI prefixes are supported. Only image types (jpg, png, gif, webp) are allowed, decoded bytes are written through `media_handle_sideload()`, and the tool still requires `upload_files`. Fixes GitHub #17.
 
 = 2.6.5 =
 * New: Elementor Advanced Design Tools — 11 tools for high-fidelity design workflows: get/update active kit, regenerate CSS, get widget schema, duplicate/move element, convert CSS to Elementor settings, get/update page settings, copy styles, and get breakpoints. All off by default under the "Elementor" group. Security: write tools run settings through `wsp_elementor_sanitize_settings()` (strips `custom_css`, `custom_attributes`, and dynamic keys); `update-active-kit` and `regenerate-css` require `manage_options`, the rest require `edit_posts`.

--- a/wsp-mcp-ai-agents-connector/wsp-mcp-ai-agents-connector.php
+++ b/wsp-mcp-ai-agents-connector/wsp-mcp-ai-agents-connector.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WSP MCP - AI Agents Connector
  * Description: Exposes WordPress content to Claude AI and other AI Agents via a built-in MCP server (no companion plugin required). Manage all abilities from Settings > MCP.
- * Version: 2.6.5
+ * Version: 2.6.6
  * Requires at least: 6.9
  * Requires PHP: 7.4
  * Author: WebSensePro
@@ -14,7 +14,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'WSP_MCP_VERSION', '2.6.5' );
+define( 'WSP_MCP_VERSION', '2.6.6' );
 define( 'WSP_MCP_OPTION', 'wsp_mcp_abilities' );
 define( 'WSP_MCP_DIR', plugin_dir_path( __FILE__ ) );
 


### PR DESCRIPTION
**Problem**
The media upload tools could only pull an image from a public URL
(`wsp_upload_media` / `wsp_upload_media_from_url`). There was no way to upload a
file attached directly in the chat, so users had to host the image somewhere
first (Google Drive, a stock URL) and paste the link.

**Fix**
`wsp_upload_media` now also accepts **base64 file content** via a new optional
`data` parameter, so any MCP client that can hand the file bytes to the tool
(Cursor, OpenCode, coding agents, etc.) can upload straight from the chat — no
URL required.

- New `wsp_execute_upload_media_from_data()` in `media.php`: `wp_unslash`, strips
  a `data:<mime>;base64,` prefix, normalizes URL-safe base64, drops stray
  characters, strict `base64_decode`, resolves a safe image filename, writes to
  `wp_tempnam()` and sideloads via `media_handle_sideload()`.
- `wsp_execute_upload_media()` routes to the base64 path when `data` is present,
  otherwise to the existing URL path. **The `url` behavior is unchanged** — pass
  either `data` or `url` (`data` wins if both are given).
- **Security unchanged:** still requires `upload_files`; only `jpg/png/gif/webp`;
  temp files are cleaned up on failure. No other tool or file was modified.
- Version bumped `2.6.5 → 2.6.6`; updated `AGENTS.md`, `CHANGELOG.md`,
  `readme.txt`, and `registry.php` per the repo's update rule.

**Testing**
Verified against a live WordPress site: a base64 upload of a real PNG succeeds
and returns the attachment with full metadata; the existing `url` path still
works as before.