### PR TITLE
fix(sync): include CF7 + WPForms groups in website abilities sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,8 +117,14 @@ website shows is derived from it. Generated artifacts live **only** in the websi
 
 **Tooling (`bin/`, dev-only — never shipped in the plugin zip):**
 - `bin/lib-abilities.php` — loads `registry.php` in a minimal WP stub (defines `ABSPATH`, stubs
-  `wsp_yoast_is_active()` / `wsp_elementor_is_active()` / `wsp_acf_is_active()` / a `WooCommerce`
-  class so **all** plugin-gated groups render), then exposes the registry + totals.
+  `wsp_yoast_is_active()` / `wsp_rankmath_is_active()` / `wsp_elementor_is_active()` /
+  `wsp_acf_is_active()` / `wsp_uae_is_active()` / `wsp_gravity_is_active()` / `wsp_cf7_is_active()` /
+  `wsp_wpforms_is_active()` / a `WooCommerce` class so **all** plugin-gated groups render), then
+  exposes the registry + totals. **When you add a plugin-gated group to `registry.php`, you MUST add
+  its active-check stub here too** — otherwise the registry's real check returns false in the
+  generator environment and the whole group is silently dropped from the website (this is exactly
+  what happened to the Contact Form 7 + WPForms groups — they shipped in `registry.php` for v2.6.6
+  but never reached the site until the stubs were added here).
 - `bin/generate-abilities-md.php` — prints `abilities.md` (default) or `abilities.json` (`--json`).
 - `bin/patch-website.php <html> <sitemap>` — rewrites the `var ABILITIES = [ … ];` array inside
   the site's `abilities-directory.html` in place, and bumps the `<lastmod>` for that page in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed — Website sync dropped Contact Form 7 + WPForms groups (`bin/lib-abilities.php`)
+- **The public Abilities Directory on freewordpressmcp.com was missing every Contact Form 7 (10) and WPForms (12) tool**, even though both groups have shipped in `registry.php` since v2.6.6. Root cause: the website-sync generator loads `registry.php` in a stub environment (`bin/lib-abilities.php`), and that stub force-activates every plugin-gated group by defining its `wsp_*_is_active()` check to return `true`. Stubs existed for Yoast, Rank Math, Elementor, ACF, UAE, Gravity Forms, and WooCommerce — but **not** for `wsp_cf7_is_active()` / `wsp_wpforms_is_active()`. Without them, `registry.php`'s own real checks ran (`class_exists('WPCF7_ContactForm')` / `function_exists('wpforms')`), both returned false in the PHP-CLI generator, and the two groups were silently skipped. This is why the automated sync PR only ever produced a trivial diff and never surfaced the 2.6.6 form tools.
+- **Fix:** added `wsp_cf7_is_active()` and `wsp_wpforms_is_active()` stubs (return `true`) to `bin/lib-abilities.php`, alongside the existing ones. The generator now emits all groups; `patch-website.php` regenerates both the `ABILITIES` array and the `GROUPS` map, so the site picks up CF7 + WPForms automatically on the next `main` push. Dev-tooling only — no plugin runtime code, tool, or shipped-zip behavior changed (the plugin already registered these tools correctly at runtime).
+- **Guardrail:** documented in `AGENTS.md` ("Website sync automation") that any new plugin-gated group added to `registry.php` MUST get a matching active-check stub in `bin/lib-abilities.php`, or it will be dropped from the site.
+
 ## [2.6.6] — 2026-07-27
 
 ### Added — Direct (base64) file upload for media (`includes/abilities/media.php`, `includes/tools/native-tools.php`, `includes/registry.php`)

--- a/bin/lib-abilities.php
+++ b/bin/lib-abilities.php
@@ -5,7 +5,10 @@
  *
  * `wsp-mcp-ai-agents-connector/includes/registry.php` is the single source of
  * truth. This file executes it in a minimal stub environment so every
- * plugin-gated group (Yoast, WooCommerce, Elementor, ACF) is included.
+ * plugin-gated group (Yoast, Rank Math, WooCommerce, Elementor, ACF, UAE,
+ * Gravity Forms, Contact Form 7, WPForms) is included. Every active-check the
+ * registry gates a group behind MUST be stubbed here, or that group is
+ * silently dropped from the generated docs and the website.
  *
  * DEV TOOLING — lives outside the plugin folder, never shipped in the zip,
  * only reads registry.php.
@@ -23,6 +26,8 @@ if ( ! function_exists( 'wsp_elementor_is_active' ) ) { function wsp_elementor_i
 if ( ! function_exists( 'wsp_acf_is_active' ) )       { function wsp_acf_is_active()       { return true; } }
 if ( ! function_exists( 'wsp_uae_is_active' ) )       { function wsp_uae_is_active()       { return true; } }
 if ( ! function_exists( 'wsp_gravity_is_active' ) )  { function wsp_gravity_is_active()  { return true; } }
+if ( ! function_exists( 'wsp_cf7_is_active' ) )       { function wsp_cf7_is_active()       { return true; } }
+if ( ! function_exists( 'wsp_wpforms_is_active' ) )   { function wsp_wpforms_is_active()   { return true; } }
 if ( ! class_exists( 'WooCommerce' ) )                { class WooCommerce {} }
 
 require __DIR__ . '/../wsp-mcp-ai-agents-connector/includes/registry.php';


### PR DESCRIPTION
The website-sync generator loads registry.php in a stub environment (bin/lib-abilities.php) that force-activates each plugin-gated group by defining its wsp_*_is_active() check to return true. Stubs existed for Yoast, Rank Math, Elementor, ACF, UAE, Gravity Forms and WooCommerce but not for CF7 or WPForms, so registry.php's real checks (class_exists('WPCF7_ContactForm') / function_exists('wpforms')) ran, returned false under PHP-CLI, and both groups (10 + 12 tools shipped in 2.6.6) were silently dropped from abilities.md/json and the site.

Add wsp_cf7_is_active() and wsp_wpforms_is_active() stubs so the generator emits all groups; patch-website.php then regenerates the ABILITIES array and GROUPS map automatically. Dev-tooling only, no plugin runtime change. Documents the guardrail in AGENTS.md + CHANGELOG.